### PR TITLE
Add Index#images_path method

### DIFF
--- a/lib/gemojione/index.rb
+++ b/lib/gemojione/index.rb
@@ -37,5 +37,9 @@ module Gemojione
     def unicode_moji_regex
       @emoji_moji_regex
     end
+
+    def images_path
+      File.expand_path("../../assets/images", File.dirname(__FILE__))
+    end
   end
 end

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -24,4 +24,12 @@ describe Gemojione::Index do
       assert "🌀".match(regex)
     end
   end
+
+  describe "images_path" do
+    it "returns a valid path" do
+      path = index.images_path
+
+      assert Dir.exist?(path)
+    end
+  end
 end


### PR DESCRIPTION
This will allow a Rails application to serve Emoji assets directly from
the gem, without copying them locally, by using a configuration similar
to the following:

``` ruby
# config/application.rb
config.assets.paths << Gemojione.index.images_path
config.assets.precompile << "emoji/*.png"
```
