### PR TITLE
Add a (nonobstructive) setting for image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Default configuration integrates with Rails, but you can change it with an initi
 # config/initializers/gemojione.rb
 Gemojione.asset_host = "emoji.cdn.com"
 Gemojione.asset_path = '/assets/emoji'
+Gemojione.default_size = '64px'
 ```
 
 You can also serve the assets directly from the gem in your rails app:

--- a/lib/gemojione.rb
+++ b/lib/gemojione.rb
@@ -15,6 +15,8 @@ require "gemojione/railtie" if defined?(Rails)
 module Gemojione
   @asset_host = nil
   @asset_path = nil
+  @default_size = nil
+
   @escaper = defined?(EscapeUtils) ? EscapeUtils : CGI
 
   def self.asset_host
@@ -33,6 +35,14 @@ module Gemojione
     @asset_path = path
   end
 
+  def self.default_size
+    @default_size
+  end
+
+  def self.default_size=(size)
+    @default_size = size
+  end
+
   def self.image_url_for_name(name)
     emoji = index.find_by_name(name)
     "#{asset_host}#{ File.join(asset_path, emoji['unicode']) }.png"
@@ -43,6 +53,10 @@ module Gemojione
     image_url_for_name(emoji['name'])
   end
 
+  def self.image_tag_for_moji(moji)
+    %Q{<img alt="#{moji}" class="emoji" src="#{ image_url_for_unicode_moji(moji) }"#{ default_size ? ' style="width: '+default_size+';"' : '' }>}
+  end
+
   def self.replace_unicode_moji_with_images(string)
     return string unless string
     unless string.match(index.unicode_moji_regex)
@@ -51,7 +65,7 @@ module Gemojione
 
     safe_string = safe_string(string.dup)
     safe_string.gsub!(index.unicode_moji_regex) do |moji|
-      %Q{<img alt="#{moji}" class="emoji" src="#{ image_url_for_unicode_moji(moji) }">}
+      Gemojione.image_tag_for_moji(moji)
     end
     safe_string = safe_string.html_safe if safe_string.respond_to?(:html_safe)
 
@@ -68,7 +82,7 @@ module Gemojione
     safe_string.gsub!(index.shortname_moji_regex) do |code|
       name = code.tr(':','')
       moji = index.find_by_name(name)['moji']
-      %Q{<img alt="#{moji}" class="emoji" src="#{ image_url_for_name(name) }">}
+      Gemojione.image_tag_for_moji(moji)
     end
     safe_string = safe_string.html_safe if safe_string.respond_to?(:html_safe)
 

--- a/test/gemojione_test.rb
+++ b/test/gemojione_test.rb
@@ -43,6 +43,30 @@ describe Gemojione do
     end
   end
 
+  describe 'default size' do
+    it 'should default to nil' do
+      assert_equal nil, Gemojione.default_size
+    end
+
+    it 'should be configurable' do
+      with_emoji_config(:default_size, '32px') do
+        assert_equal '32px', Gemojione.default_size
+      end
+    end
+  end
+
+  describe 'image_tag_for_moji' do
+    it 'should generate a clean img tag if default_size undefined' do
+      assert_equal '<img alt="🌀" class="emoji" src="http://localhost:3000/1F300.png">', Gemojione.image_tag_for_moji('🌀')
+    end
+
+    it 'should generate a img tag with style tag if default_size is defined' do
+      Gemojione.default_size='42px'
+      assert_equal '<img alt="🌀" class="emoji" src="http://localhost:3000/1F300.png" style="width: 42px;">', Gemojione.image_tag_for_moji('🌀')
+      Gemojione.default_size=nil
+    end
+  end
+
   describe "replace_unicode_moji_with_images" do
     it 'should return original string without emoji' do
       assert_equal "foo", Gemojione.replace_unicode_moji_with_images('foo')


### PR DESCRIPTION
Hi again. This time I've added a (nonobstructive) setting for image size, since we are using this tool to render Emojis into html emails :sweat_smile: and therefor we needed a way to add an inline styling to change the size. (Quite huge in a normal text flow) :see_no_evil: 

However - as you can see in the tests - nothing changed for any functionality. If it isn't set, it will be completely ignored (so `class="emoji"` still "works") . Hope that makes sense. 
