### PR TITLE
Remove duplicate defs same unicode

### DIFF
--- a/config/index.json
+++ b/config/index.json
@@ -5723,22 +5723,6 @@
     ],
     "moji": "🎛"
   },
-  "contruction_site": {
-    "unicode": "1F3D7",
-    "unicode_alternates": [],
-    "name": "building construction",
-    "shortname": ":contruction_site:",
-    "category": "travel_places",
-    "aliases": [
-      ":building_construction:"
-    ],
-    "aliases_ascii": [],
-    "keywords": [
-      "site",
-      "work"
-    ],
-    "moji": "🏗"
-  },
   "convenience_store": {
     "unicode": "1F3EA",
     "unicode_alternates": [],
@@ -17330,21 +17314,6 @@
       "midi"
     ],
     "moji": "🎘"
-  },
-  "keycap_ten": {
-    "unicode": "1F51F",
-    "unicode_alternates": [],
-    "name": "keycap ten",
-    "shortname": ":keycap_ten:",
-    "category": "symbols",
-    "aliases": [],
-    "aliases_ascii": [],
-    "keywords": [
-      "10",
-      "blue-square",
-      "numbers"
-    ],
-    "moji": "🔟"
   },
   "kimono": {
     "unicode": "1F458",

--- a/config/index.json
+++ b/config/index.json
@@ -15038,7 +15038,7 @@
       "smiley",
       "emotion"
     ],
-    "moji": "🕧"
+    "moji": "😀"
   },
   "guardsman": {
     "unicode": "1F482",


### PR DESCRIPTION
Eliminated the following definitions:
- `contruction_site` was misspelled, the right one `construction_site` stays.
- `keycap_ten`, since the other "keycaps" are just the number name (like `nine`, `eight`, even the keycap asterisk is just `asterisk`), then it makes sense to remove this one and leave `ten`.

Other change identified when deduping was the incorrect moji for the `grinning` def. It had the `clock1234` moji instead.

This fixes #13 
