### PR TITLE
Rails check updated

### DIFF
--- a/lib/gemojione.rb
+++ b/lib/gemojione.rb
@@ -10,7 +10,7 @@ end
 
 require 'gemojione/index'
 
-require "gemojione/railtie" if defined?(Rails)
+require 'gemojione/railtie' if defined?(Rails::Railtie)
 
 module Gemojione
   @asset_host = nil


### PR DESCRIPTION
Hi, we are not using Rails, but `actionmailer` (4.2.4) which depends on `rails-dom-testing` which has a Rails module https://github.com/rails/rails-dom-testing/blob/5efc948e3572906965c4ed2f67000e59a7094e62/lib/rails/dom/testing/version.rb 

```
module Rails
  module Dom
    module Testing
      VERSION = "2.0.1"
    end
  end
end
```

Gemfile.lock:

```
actionmailer (4.2.4)
  actionpack (= 4.2.4)
  actionview (= 4.2.4)
  activejob (= 4.2.4)
  mail (~> 2.5, >= 2.5.4)
  rails-dom-testing (~> 1.0, >= 1.0.5) 
```

This change seems to fix it.
