### PR TITLE
[WIP] Add emoji order

### DIFF
--- a/config/index.json
+++ b/config/index.json
@@ -24,7 +24,8 @@
       "win",
       "parties"
     ],
-    "moji": "💯"
+    "moji": "💯",
+    "emoji_order": 856
   },
   "1234": {
     "unicode": "1F522",
@@ -39,7 +40,8 @@
       "numbers",
       "symbol"
     ],
-    "moji": "🔢"
+    "moji": "🔢",
+    "emoji_order": 913
   },
   "8ball": {
     "unicode": "1F3B1",
@@ -61,7 +63,8 @@
       "luck",
       "boys night"
     ],
-    "moji": "🎱"
+    "moji": "🎱",
+    "emoji_order": 426
   },
   "a": {
     "unicode": "1F170",
@@ -77,7 +80,8 @@
       "red-square",
       "symbol"
     ],
-    "moji": "🅰"
+    "moji": "🅰",
+    "emoji_order": 831
   },
   "ab": {
     "unicode": "1F18E",
@@ -92,7 +96,8 @@
       "red-square",
       "symbol"
     ],
-    "moji": "🆎"
+    "moji": "🆎",
+    "emoji_order": 833
   },
   "abc": {
     "unicode": "1F524",
@@ -107,7 +112,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "🔤"
+    "moji": "🔤",
+    "emoji_order": 949
   },
   "abcd": {
     "unicode": "1F521",
@@ -122,7 +128,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "🔡"
+    "moji": "🔡",
+    "emoji_order": 950
   },
   "accept": {
     "unicode": "1F251",
@@ -141,7 +148,8 @@
       "yes",
       "symbol"
     ],
-    "moji": "🉑"
+    "moji": "🉑",
+    "emoji_order": 823
   },
   "aerial_tramway": {
     "unicode": "1F6A1",
@@ -162,7 +170,8 @@
       "travel",
       "train"
     ],
-    "moji": "🚡"
+    "moji": "🚡",
+    "emoji_order": 496
   },
   "airplane": {
     "unicode": "2708",
@@ -190,7 +199,8 @@
       "airbus",
       "vacation"
     ],
-    "moji": "✈"
+    "moji": "✈",
+    "emoji_order": 513
   },
   "airplane_arriving": {
     "unicode": "1F6EC",
@@ -215,7 +225,8 @@
       "airbus",
       "vacation"
     ],
-    "moji": "🛬"
+    "moji": "🛬",
+    "emoji_order": 515
   },
   "airplane_departure": {
     "unicode": "1F6EB",
@@ -241,7 +252,8 @@
       "leaving",
       "vacation"
     ],
-    "moji": "🛫"
+    "moji": "🛫",
+    "emoji_order": 514
   },
   "airplane_small": {
     "unicode": "1F6E9",
@@ -268,7 +280,8 @@
       "airbus",
       "vacation"
     ],
-    "moji": "🛩"
+    "moji": "🛩",
+    "emoji_order": 512
   },
   "alarm_clock": {
     "unicode": "23F0",
@@ -283,7 +296,8 @@
       "wake",
       "object"
     ],
-    "moji": "⏰"
+    "moji": "⏰",
+    "emoji_order": 624
   },
   "alembic": {
     "unicode": "2697",
@@ -299,7 +313,8 @@
       "tool",
       "science"
     ],
-    "moji": "⚗"
+    "moji": "⚗",
+    "emoji_order": 667
   },
   "alien": {
     "unicode": "1F47D",
@@ -318,7 +333,8 @@
       "monster",
       "scientology"
     ],
-    "moji": "👽"
+    "moji": "👽",
+    "emoji_order": 77
   },
   "ambulance": {
     "unicode": "1F691",
@@ -338,7 +354,8 @@
       "assistance",
       "transportation"
     ],
-    "moji": "🚑"
+    "moji": "🚑",
+    "emoji_order": 483
   },
   "amphora": {
     "unicode": "1F3FA",
@@ -351,7 +368,8 @@
     "keywords": [
       "object"
     ],
-    "moji": "🏺"
+    "moji": "🏺",
+    "emoji_order": 663
   },
   "anchor": {
     "unicode": "2693",
@@ -378,7 +396,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "⚓"
+    "moji": "⚓",
+    "emoji_order": 524
   },
   "angel": {
     "unicode": "1F47C",
@@ -400,7 +419,8 @@
       "diversity",
       "omg"
     ],
-    "moji": "👼"
+    "moji": "👼",
+    "emoji_order": 136
   },
   "angel_tone1": {
     "unicode": "1F47C-1F3FB",
@@ -417,7 +437,8 @@
       "wings",
       "jesus"
     ],
-    "moji": "👼🏻"
+    "moji": "👼🏻",
+    "emoji_order": 1495
   },
   "angel_tone2": {
     "unicode": "1F47C-1F3FC",
@@ -434,7 +455,8 @@
       "wings",
       "jesus"
     ],
-    "moji": "👼🏼"
+    "moji": "👼🏼",
+    "emoji_order": 1496
   },
   "angel_tone3": {
     "unicode": "1F47C-1F3FD",
@@ -451,7 +473,8 @@
       "wings",
       "jesus"
     ],
-    "moji": "👼🏽"
+    "moji": "👼🏽",
+    "emoji_order": 1497
   },
   "angel_tone4": {
     "unicode": "1F47C-1F3FE",
@@ -468,7 +491,8 @@
       "wings",
       "jesus"
     ],
-    "moji": "👼🏾"
+    "moji": "👼🏾",
+    "emoji_order": 1498
   },
   "angel_tone5": {
     "unicode": "1F47C-1F3FF",
@@ -485,7 +509,8 @@
       "wings",
       "jesus"
     ],
-    "moji": "👼🏿"
+    "moji": "👼🏿",
+    "emoji_order": 1499
   },
   "anger": {
     "unicode": "1F4A2",
@@ -501,7 +526,8 @@
       "mad",
       "symbol"
     ],
-    "moji": "💢"
+    "moji": "💢",
+    "emoji_order": 842
   },
   "anger_right": {
     "unicode": "1F5EF",
@@ -524,7 +550,8 @@
       "angry",
       "symbol"
     ],
-    "moji": "🗯"
+    "moji": "🗯",
+    "emoji_order": 1011
   },
   "angry": {
     "unicode": "1F620",
@@ -550,7 +577,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😠"
+    "moji": "😠",
+    "emoji_order": 39
   },
   "anguished": {
     "unicode": "1F627",
@@ -575,7 +603,8 @@
       "surprised",
       "emotion"
     ],
-    "moji": "😧"
+    "moji": "😧",
+    "emoji_order": 56
   },
   "ant": {
     "unicode": "1F41C",
@@ -593,7 +622,8 @@
       "team",
       "insects"
     ],
-    "moji": "🐜"
+    "moji": "🐜",
+    "emoji_order": 239
   },
   "apple": {
     "unicode": "1F34E",
@@ -616,7 +646,8 @@
       "food",
       "creationism"
     ],
-    "moji": "🍎"
+    "moji": "🍎",
+    "emoji_order": 353
   },
   "aquarius": {
     "unicode": "2652",
@@ -642,7 +673,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♒"
+    "moji": "♒",
+    "emoji_order": 806
   },
   "aries": {
     "unicode": "2648",
@@ -667,7 +699,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♈"
+    "moji": "♈",
+    "emoji_order": 796
   },
   "arrow_backward": {
     "unicode": "25C0",
@@ -685,7 +718,8 @@
       "symbol",
       "triangle"
     ],
-    "moji": "◀"
+    "moji": "◀",
+    "emoji_order": 926
   },
   "arrow_double_down": {
     "unicode": "23EC",
@@ -700,7 +734,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "⏬"
+    "moji": "⏬",
+    "emoji_order": 930
   },
   "arrow_double_up": {
     "unicode": "23EB",
@@ -715,7 +750,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "⏫"
+    "moji": "⏫",
+    "emoji_order": 929
   },
   "arrow_down": {
     "unicode": "2B07",
@@ -732,7 +768,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "⬇"
+    "moji": "⬇",
+    "emoji_order": 934
   },
   "arrow_down_small": {
     "unicode": "1F53D",
@@ -748,7 +785,8 @@
       "symbol",
       "triangle"
     ],
-    "moji": "🔽"
+    "moji": "🔽",
+    "emoji_order": 928
   },
   "arrow_forward": {
     "unicode": "25B6",
@@ -766,7 +804,8 @@
       "symbol",
       "triangle"
     ],
-    "moji": "▶"
+    "moji": "▶",
+    "emoji_order": 914
   },
   "arrow_heading_down": {
     "unicode": "2935",
@@ -783,7 +822,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "⤵"
+    "moji": "⤵",
+    "emoji_order": 945
   },
   "arrow_heading_up": {
     "unicode": "2934",
@@ -800,7 +840,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "⤴"
+    "moji": "⤴",
+    "emoji_order": 944
   },
   "arrow_left": {
     "unicode": "2B05",
@@ -818,7 +859,8 @@
       "previous",
       "symbol"
     ],
-    "moji": "⬅"
+    "moji": "⬅",
+    "emoji_order": 932
   },
   "arrow_lower_left": {
     "unicode": "2199",
@@ -835,7 +877,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "↙"
+    "moji": "↙",
+    "emoji_order": 937
   },
   "arrow_lower_right": {
     "unicode": "2198",
@@ -852,7 +895,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "↘"
+    "moji": "↘",
+    "emoji_order": 936
   },
   "arrow_right": {
     "unicode": "27A1",
@@ -870,7 +914,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "➡"
+    "moji": "➡",
+    "emoji_order": 931
   },
   "arrow_right_hook": {
     "unicode": "21AA",
@@ -887,7 +932,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "↪"
+    "moji": "↪",
+    "emoji_order": 942
   },
   "arrow_up": {
     "unicode": "2B06",
@@ -904,7 +950,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "⬆"
+    "moji": "⬆",
+    "emoji_order": 933
   },
   "arrow_up_down": {
     "unicode": "2195",
@@ -921,7 +968,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "↕"
+    "moji": "↕",
+    "emoji_order": 939
   },
   "arrow_up_small": {
     "unicode": "1F53C",
@@ -937,7 +985,8 @@
       "symbol",
       "triangle"
     ],
-    "moji": "🔼"
+    "moji": "🔼",
+    "emoji_order": 927
   },
   "arrow_upper_left": {
     "unicode": "2196",
@@ -954,7 +1003,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "↖"
+    "moji": "↖",
+    "emoji_order": 938
   },
   "arrow_upper_right": {
     "unicode": "2197",
@@ -971,7 +1021,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "↗"
+    "moji": "↗",
+    "emoji_order": 935
   },
   "arrows_clockwise": {
     "unicode": "1F503",
@@ -986,7 +1037,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "🔃"
+    "moji": "🔃",
+    "emoji_order": 958
   },
   "arrows_counterclockwise": {
     "unicode": "1F504",
@@ -1002,7 +1054,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "🔄"
+    "moji": "🔄",
+    "emoji_order": 941
   },
   "art": {
     "unicode": "1F3A8",
@@ -1024,7 +1077,8 @@
       "pastels",
       "oils"
     ],
-    "moji": "🎨"
+    "moji": "🎨",
+    "emoji_order": 459
   },
   "articulated_lorry": {
     "unicode": "1F69B",
@@ -1044,7 +1098,8 @@
       "lorry",
       "articulated"
     ],
-    "moji": "🚛"
+    "moji": "🚛",
+    "emoji_order": 487
   },
   "asterisk": {
     "unicode": "002A-20E3",
@@ -1063,7 +1118,8 @@
       "star",
       "symbol"
     ],
-    "moji": "*⃣"
+    "moji": "*⃣",
+    "emoji_order": 947
   },
   "astonished": {
     "unicode": "1F632",
@@ -1085,7 +1141,8 @@
       "emotion",
       "omg"
     ],
-    "moji": "😲"
+    "moji": "😲",
+    "emoji_order": 63
   },
   "athletic_shoe": {
     "unicode": "1F45F",
@@ -1103,7 +1160,8 @@
       "accessories",
       "boys night"
     ],
-    "moji": "👟"
+    "moji": "👟",
+    "emoji_order": 190
   },
   "atm": {
     "unicode": "1F3E7",
@@ -1128,7 +1186,8 @@
       "electronics",
       "symbol"
     ],
-    "moji": "🏧"
+    "moji": "🏧",
+    "emoji_order": 877
   },
   "atom": {
     "unicode": "269B",
@@ -1145,7 +1204,8 @@
       "symbol",
       "science"
     ],
-    "moji": "⚛"
+    "moji": "⚛",
+    "emoji_order": 809
   },
   "avocado": {
     "unicode": "1F951",
@@ -1156,7 +1216,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥑"
+    "moji": "🥑",
+    "emoji_order": 10138
   },
   "b": {
     "unicode": "1F171",
@@ -1172,7 +1233,8 @@
       "red-square",
       "symbol"
     ],
-    "moji": "🅱"
+    "moji": "🅱",
+    "emoji_order": 832
   },
   "baby": {
     "unicode": "1F476",
@@ -1190,7 +1252,8 @@
       "baby",
       "diversity"
     ],
-    "moji": "👶"
+    "moji": "👶",
+    "emoji_order": 121
   },
   "baby_bottle": {
     "unicode": "1F37C",
@@ -1213,7 +1276,8 @@
       "drink",
       "object"
     ],
-    "moji": "🍼"
+    "moji": "🍼",
+    "emoji_order": 416
   },
   "baby_chick": {
     "unicode": "1F424",
@@ -1233,7 +1297,8 @@
       "woman",
       "cute"
     ],
-    "moji": "🐤"
+    "moji": "🐤",
+    "emoji_order": 228
   },
   "baby_symbol": {
     "unicode": "1F6BC",
@@ -1255,7 +1320,8 @@
       "babe",
       "symbol"
     ],
-    "moji": "🚼"
+    "moji": "🚼",
+    "emoji_order": 890
   },
   "baby_tone1": {
     "unicode": "1F476-1F3FB",
@@ -1270,7 +1336,8 @@
       "infant",
       "toddler"
     ],
-    "moji": "👶🏻"
+    "moji": "👶🏻",
+    "emoji_order": 1425
   },
   "baby_tone2": {
     "unicode": "1F476-1F3FC",
@@ -1285,7 +1352,8 @@
       "infant",
       "toddler"
     ],
-    "moji": "👶🏼"
+    "moji": "👶🏼",
+    "emoji_order": 1426
   },
   "baby_tone3": {
     "unicode": "1F476-1F3FD",
@@ -1300,7 +1368,8 @@
       "infant",
       "toddler"
     ],
-    "moji": "👶🏽"
+    "moji": "👶🏽",
+    "emoji_order": 1427
   },
   "baby_tone4": {
     "unicode": "1F476-1F3FE",
@@ -1315,7 +1384,8 @@
       "infant",
       "toddler"
     ],
-    "moji": "👶🏾"
+    "moji": "👶🏾",
+    "emoji_order": 1428
   },
   "baby_tone5": {
     "unicode": "1F476-1F3FF",
@@ -1330,7 +1400,8 @@
       "infant",
       "toddler"
     ],
-    "moji": "👶🏿"
+    "moji": "👶🏿",
+    "emoji_order": 1429
   },
   "back": {
     "unicode": "1F519",
@@ -1344,7 +1415,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "🔙"
+    "moji": "🔙",
+    "emoji_order": 969
   },
   "bacon": {
     "unicode": "1F953",
@@ -1357,7 +1429,8 @@
     "keywords": [
       "pig"
     ],
-    "moji": "🥓"
+    "moji": "🥓",
+    "emoji_order": 10140
   },
   "badminton": {
     "unicode": "1F3F8",
@@ -1372,7 +1445,8 @@
       "sport",
       "badminton"
     ],
-    "moji": "🏸"
+    "moji": "🏸",
+    "emoji_order": 430
   },
   "baggage_claim": {
     "unicode": "1F6C4",
@@ -1392,7 +1466,8 @@
       "travel",
       "symbol"
     ],
-    "moji": "🛄"
+    "moji": "🛄",
+    "emoji_order": 881
   },
   "balloon": {
     "unicode": "1F388",
@@ -1415,7 +1490,8 @@
       "good",
       "parties"
     ],
-    "moji": "🎈"
+    "moji": "🎈",
+    "emoji_order": 691
   },
   "ballot_box": {
     "unicode": "1F5F3",
@@ -1432,7 +1508,8 @@
       "object",
       "office"
     ],
-    "moji": "🗳"
+    "moji": "🗳",
+    "emoji_order": 727
   },
   "ballot_box_with_check": {
     "unicode": "2611",
@@ -1449,7 +1526,8 @@
       "ok",
       "symbol"
     ],
-    "moji": "☑"
+    "moji": "☑",
+    "emoji_order": 973
   },
   "bamboo": {
     "unicode": "1F38D",
@@ -1478,7 +1556,8 @@
       "farming",
       "agriculture"
     ],
-    "moji": "🎍"
+    "moji": "🎍",
+    "emoji_order": 287
   },
   "banana": {
     "unicode": "1F34C",
@@ -1496,7 +1575,8 @@
       "bunch",
       "penis"
     ],
-    "moji": "🍌"
+    "moji": "🍌",
+    "emoji_order": 357
   },
   "bangbang": {
     "unicode": "203C",
@@ -1514,7 +1594,8 @@
       "symbol",
       "punctuation"
     ],
-    "moji": "‼"
+    "moji": "‼",
+    "emoji_order": 854
   },
   "bank": {
     "unicode": "1F3E6",
@@ -1528,7 +1609,8 @@
       "building",
       "places"
     ],
-    "moji": "🏦"
+    "moji": "🏦",
+    "emoji_order": 579
   },
   "bar_chart": {
     "unicode": "1F4CA",
@@ -1545,7 +1627,8 @@
       "work",
       "office"
     ],
-    "moji": "📊"
+    "moji": "📊",
+    "emoji_order": 718
   },
   "barber": {
     "unicode": "1F488",
@@ -1561,7 +1644,8 @@
       "style",
       "object"
     ],
-    "moji": "💈"
+    "moji": "💈",
+    "emoji_order": 666
   },
   "baseball": {
     "unicode": "26BE",
@@ -1582,7 +1666,8 @@
       "sport",
       "baseball"
     ],
-    "moji": "⚾"
+    "moji": "⚾",
+    "emoji_order": 422
   },
   "basketball": {
     "unicode": "1F3C0",
@@ -1607,7 +1692,8 @@
       "ball",
       "sport"
     ],
-    "moji": "🏀"
+    "moji": "🏀",
+    "emoji_order": 420
   },
   "basketball_player": {
     "unicode": "26F9",
@@ -1628,7 +1714,8 @@
       "basketball",
       "diversity"
     ],
-    "moji": "⛹"
+    "moji": "⛹",
+    "emoji_order": 444
   },
   "basketball_player_tone1": {
     "unicode": "26F9-1F3FB",
@@ -1648,7 +1735,8 @@
       "ball",
       "basketball"
     ],
-    "moji": "⛹🏻"
+    "moji": "⛹🏻",
+    "emoji_order": 1590
   },
   "basketball_player_tone2": {
     "unicode": "26F9-1F3FC",
@@ -1668,7 +1756,8 @@
       "ball",
       "basketball"
     ],
-    "moji": "⛹🏼"
+    "moji": "⛹🏼",
+    "emoji_order": 1591
   },
   "basketball_player_tone3": {
     "unicode": "26F9-1F3FD",
@@ -1688,7 +1777,8 @@
       "ball",
       "basketball"
     ],
-    "moji": "⛹🏽"
+    "moji": "⛹🏽",
+    "emoji_order": 1592
   },
   "basketball_player_tone4": {
     "unicode": "26F9-1F3FE",
@@ -1708,7 +1798,8 @@
       "ball",
       "basketball"
     ],
-    "moji": "⛹🏾"
+    "moji": "⛹🏾",
+    "emoji_order": 1593
   },
   "basketball_player_tone5": {
     "unicode": "26F9-1F3FF",
@@ -1728,7 +1819,8 @@
       "ball",
       "basketball"
     ],
-    "moji": "⛹🏿"
+    "moji": "⛹🏿",
+    "emoji_order": 1594
   },
   "bat": {
     "unicode": "1F987",
@@ -1739,7 +1831,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦇"
+    "moji": "🦇",
+    "emoji_order": 10127
   },
   "bath": {
     "unicode": "1F6C0",
@@ -1767,7 +1860,8 @@
       "diversity",
       "steam"
     ],
-    "moji": "🛀"
+    "moji": "🛀",
+    "emoji_order": 443
   },
   "bath_tone1": {
     "unicode": "1F6C0-1F3FB",
@@ -1791,7 +1885,8 @@
       "shampoo",
       "lather"
     ],
-    "moji": "🛀🏻"
+    "moji": "🛀🏻",
+    "emoji_order": 1585
   },
   "bath_tone2": {
     "unicode": "1F6C0-1F3FC",
@@ -1815,7 +1910,8 @@
       "shampoo",
       "lather"
     ],
-    "moji": "🛀🏼"
+    "moji": "🛀🏼",
+    "emoji_order": 1586
   },
   "bath_tone3": {
     "unicode": "1F6C0-1F3FD",
@@ -1839,7 +1935,8 @@
       "shampoo",
       "lather"
     ],
-    "moji": "🛀🏽"
+    "moji": "🛀🏽",
+    "emoji_order": 1587
   },
   "bath_tone4": {
     "unicode": "1F6C0-1F3FE",
@@ -1863,7 +1960,8 @@
       "shampoo",
       "lather"
     ],
-    "moji": "🛀🏾"
+    "moji": "🛀🏾",
+    "emoji_order": 1588
   },
   "bath_tone5": {
     "unicode": "1F6C0-1F3FF",
@@ -1887,7 +1985,8 @@
       "shampoo",
       "lather"
     ],
-    "moji": "🛀🏿"
+    "moji": "🛀🏿",
+    "emoji_order": 1589
   },
   "bathtub": {
     "unicode": "1F6C1",
@@ -1915,7 +2014,8 @@
       "tired",
       "steam"
     ],
-    "moji": "🛁"
+    "moji": "🛁",
+    "emoji_order": 678
   },
   "battery": {
     "unicode": "1F50B",
@@ -1931,7 +2031,8 @@
       "sustain",
       "object"
     ],
-    "moji": "🔋"
+    "moji": "🔋",
+    "emoji_order": 629
   },
   "beach": {
     "unicode": "1F3D6",
@@ -1958,7 +2059,8 @@
       "beach",
       "swim"
     ],
-    "moji": "🏖"
+    "moji": "🏖",
+    "emoji_order": 554
   },
   "beach_umbrella": {
     "unicode": "26F1",
@@ -1979,7 +2081,8 @@
       "vacation",
       "tropical"
     ],
-    "moji": "⛱"
+    "moji": "⛱",
+    "emoji_order": 688
   },
   "bear": {
     "unicode": "1F43B",
@@ -1995,7 +2098,8 @@
       "wildlife",
       "roar"
     ],
-    "moji": "🐻"
+    "moji": "🐻",
+    "emoji_order": 210
   },
   "bed": {
     "unicode": "1F6CF",
@@ -2016,7 +2120,8 @@
       "object",
       "tired"
     ],
-    "moji": "🛏"
+    "moji": "🛏",
+    "emoji_order": 683
   },
   "bee": {
     "unicode": "1F41D",
@@ -2041,7 +2146,8 @@
       "pollination",
       "insects"
     ],
-    "moji": "🐝"
+    "moji": "🐝",
+    "emoji_order": 235
   },
   "beer": {
     "unicode": "1F37A",
@@ -2073,7 +2179,8 @@
       "alcohol",
       "parties"
     ],
-    "moji": "🍺"
+    "moji": "🍺",
+    "emoji_order": 407
   },
   "beers": {
     "unicode": "1F37B",
@@ -2105,7 +2212,8 @@
       "boys night",
       "parties"
     ],
-    "moji": "🍻"
+    "moji": "🍻",
+    "emoji_order": 408
   },
   "beetle": {
     "unicode": "1F41E",
@@ -2129,7 +2237,8 @@
       "insects",
       "animal"
     ],
-    "moji": "🐞"
+    "moji": "🐞",
+    "emoji_order": 238
   },
   "beginner": {
     "unicode": "1F530",
@@ -2144,7 +2253,8 @@
       "shield",
       "symbol"
     ],
-    "moji": "🔰"
+    "moji": "🔰",
+    "emoji_order": 864
   },
   "bell": {
     "unicode": "1F514",
@@ -2164,7 +2274,8 @@
       "alarm",
       "symbol"
     ],
-    "moji": "🔔"
+    "moji": "🔔",
+    "emoji_order": 1001
   },
   "bellhop": {
     "unicode": "1F6CE",
@@ -2182,7 +2293,8 @@
       "ding",
       "object"
     ],
-    "moji": "🛎"
+    "moji": "🛎",
+    "emoji_order": 685
   },
   "bento": {
     "unicode": "1F371",
@@ -2206,7 +2318,8 @@
       "sushi",
       "japan"
     ],
-    "moji": "🍱"
+    "moji": "🍱",
+    "emoji_order": 388
   },
   "bicyclist": {
     "unicode": "1F6B4",
@@ -2231,7 +2344,8 @@
       "sport",
       "diversity"
     ],
-    "moji": "🚴"
+    "moji": "🚴",
+    "emoji_order": 446
   },
   "bicyclist_tone1": {
     "unicode": "1F6B4-1F3FB",
@@ -2251,7 +2365,8 @@
       "bicycle",
       "transportation"
     ],
-    "moji": "🚴🏻"
+    "moji": "🚴🏻",
+    "emoji_order": 1600
   },
   "bicyclist_tone2": {
     "unicode": "1F6B4-1F3FC",
@@ -2271,7 +2386,8 @@
       "bicycle",
       "transportation"
     ],
-    "moji": "🚴🏼"
+    "moji": "🚴🏼",
+    "emoji_order": 1601
   },
   "bicyclist_tone3": {
     "unicode": "1F6B4-1F3FD",
@@ -2291,7 +2407,8 @@
       "bicycle",
       "transportation"
     ],
-    "moji": "🚴🏽"
+    "moji": "🚴🏽",
+    "emoji_order": 1602
   },
   "bicyclist_tone4": {
     "unicode": "1F6B4-1F3FE",
@@ -2311,7 +2428,8 @@
       "bicycle",
       "transportation"
     ],
-    "moji": "🚴🏾"
+    "moji": "🚴🏾",
+    "emoji_order": 1603
   },
   "bicyclist_tone5": {
     "unicode": "1F6B4-1F3FF",
@@ -2331,7 +2449,8 @@
       "bicycle",
       "transportation"
     ],
-    "moji": "🚴🏿"
+    "moji": "🚴🏿",
+    "emoji_order": 1604
   },
   "bike": {
     "unicode": "1F6B2",
@@ -2351,7 +2470,8 @@
       "transportation",
       "travel"
     ],
-    "moji": "🚲"
+    "moji": "🚲",
+    "emoji_order": 490
   },
   "bikini": {
     "unicode": "1F459",
@@ -2374,7 +2494,8 @@
       "tropical",
       "swim"
     ],
-    "moji": "👙"
+    "moji": "👙",
+    "emoji_order": 181
   },
   "biohazard": {
     "unicode": "2623",
@@ -2390,7 +2511,8 @@
       "symbol",
       "science"
     ],
-    "moji": "☣"
+    "moji": "☣",
+    "emoji_order": 813
   },
   "bird": {
     "unicode": "1F426",
@@ -2407,7 +2529,8 @@
       "tweet",
       "wildlife"
     ],
-    "moji": "🐦"
+    "moji": "🐦",
+    "emoji_order": 227
   },
   "birthday": {
     "unicode": "1F382",
@@ -2428,7 +2551,8 @@
       "food",
       "parties"
     ],
-    "moji": "🎂"
+    "moji": "🎂",
+    "emoji_order": 399
   },
   "black_circle": {
     "unicode": "26AB",
@@ -2446,7 +2570,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "⚫"
+    "moji": "⚫",
+    "emoji_order": 976
   },
   "black_heart": {
     "unicode": "1F5A4",
@@ -2457,7 +2582,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🖤"
+    "moji": "🖤",
+    "emoji_order": 10124
   },
   "black_joker": {
     "unicode": "1F0CF",
@@ -2474,7 +2600,8 @@
       "object",
       "symbol"
     ],
-    "moji": "🃏"
+    "moji": "🃏",
+    "emoji_order": 1003
   },
   "black_large_square": {
     "unicode": "2B1B",
@@ -2492,7 +2619,8 @@
       "symbol",
       "square"
     ],
-    "moji": "⬛"
+    "moji": "⬛",
+    "emoji_order": 986
   },
   "black_medium_small_square": {
     "unicode": "25FE",
@@ -2509,7 +2637,8 @@
       "symbol",
       "square"
     ],
-    "moji": "◾"
+    "moji": "◾",
+    "emoji_order": 991
   },
   "black_medium_square": {
     "unicode": "25FC",
@@ -2527,7 +2656,8 @@
       "symbol",
       "square"
     ],
-    "moji": "◼"
+    "moji": "◼",
+    "emoji_order": 989
   },
   "black_nib": {
     "unicode": "2712",
@@ -2546,7 +2676,8 @@
       "office",
       "write"
     ],
-    "moji": "✒"
+    "moji": "✒",
+    "emoji_order": 762
   },
   "black_small_square": {
     "unicode": "25AA",
@@ -2563,7 +2694,8 @@
       "symbol",
       "square"
     ],
-    "moji": "▪"
+    "moji": "▪",
+    "emoji_order": 984
   },
   "black_square_button": {
     "unicode": "1F532",
@@ -2579,7 +2711,8 @@
       "symbol",
       "square"
     ],
-    "moji": "🔲"
+    "moji": "🔲",
+    "emoji_order": 993
   },
   "blossom": {
     "unicode": "1F33C",
@@ -2598,7 +2731,8 @@
       "flower",
       "plant"
     ],
-    "moji": "🌼"
+    "moji": "🌼",
+    "emoji_order": 297
   },
   "blowfish": {
     "unicode": "1F421",
@@ -2623,7 +2757,8 @@
       "wildlife",
       "animal"
     ],
-    "moji": "🐡"
+    "moji": "🐡",
+    "emoji_order": 247
   },
   "blue_book": {
     "unicode": "1F4D8",
@@ -2642,7 +2777,8 @@
       "write",
       "book"
     ],
-    "moji": "📘"
+    "moji": "📘",
+    "emoji_order": 739
   },
   "blue_car": {
     "unicode": "1F699",
@@ -2660,7 +2796,8 @@
       "transportation",
       "travel"
     ],
-    "moji": "🚙"
+    "moji": "🚙",
+    "emoji_order": 478
   },
   "blue_heart": {
     "unicode": "1F499",
@@ -2683,7 +2820,8 @@
       "trust",
       "symbol"
     ],
-    "moji": "💙"
+    "moji": "💙",
+    "emoji_order": 772
   },
   "blush": {
     "unicode": "1F60A",
@@ -2707,7 +2845,8 @@
       "good",
       "beautiful"
     ],
-    "moji": "😊"
+    "moji": "😊",
+    "emoji_order": 11
   },
   "boar": {
     "unicode": "1F417",
@@ -2722,7 +2861,8 @@
       "nature",
       "wildlife"
     ],
-    "moji": "🐗"
+    "moji": "🐗",
+    "emoji_order": 232
   },
   "bomb": {
     "unicode": "1F4A3",
@@ -2740,7 +2880,8 @@
       "dead",
       "blast"
     ],
-    "moji": "💣"
+    "moji": "💣",
+    "emoji_order": 654
   },
   "book": {
     "unicode": "1F4D6",
@@ -2758,7 +2899,8 @@
       "write",
       "book"
     ],
-    "moji": "📖"
+    "moji": "📖",
+    "emoji_order": 744
   },
   "bookmark": {
     "unicode": "1F516",
@@ -2773,7 +2915,8 @@
       "object",
       "book"
     ],
-    "moji": "🔖"
+    "moji": "🔖",
+    "emoji_order": 675
   },
   "bookmark_tabs": {
     "unicode": "1F4D1",
@@ -2788,7 +2931,8 @@
       "office",
       "write"
     ],
-    "moji": "📑"
+    "moji": "📑",
+    "emoji_order": 717
   },
   "books": {
     "unicode": "1F4DA",
@@ -2806,7 +2950,8 @@
       "write",
       "book"
     ],
-    "moji": "📚"
+    "moji": "📚",
+    "emoji_order": 743
   },
   "boom": {
     "unicode": "1F4A5",
@@ -2830,7 +2975,8 @@
       "symbol",
       "blast"
     ],
-    "moji": "💥"
+    "moji": "💥",
+    "emoji_order": 338
   },
   "boot": {
     "unicode": "1F462",
@@ -2848,7 +2994,8 @@
       "sexy",
       "accessories"
     ],
-    "moji": "👢"
+    "moji": "👢",
+    "emoji_order": 188
   },
   "bouquet": {
     "unicode": "1F490",
@@ -2866,7 +3013,8 @@
       "rip",
       "condolence"
     ],
-    "moji": "💐"
+    "moji": "💐",
+    "emoji_order": 299
   },
   "bow": {
     "unicode": "1F647",
@@ -2889,7 +3037,8 @@
       "pray",
       "diversity"
     ],
-    "moji": "🙇"
+    "moji": "🙇",
+    "emoji_order": 146
   },
   "bow_and_arrow": {
     "unicode": "1F3F9",
@@ -2905,7 +3054,8 @@
       "weapon",
       "sport"
     ],
-    "moji": "🏹"
+    "moji": "🏹",
+    "emoji_order": 438
   },
   "bow_tone1": {
     "unicode": "1F647-1F3FB",
@@ -2924,7 +3074,8 @@
       "respect",
       "bend"
     ],
-    "moji": "🙇🏻"
+    "moji": "🙇🏻",
+    "emoji_order": 1525
   },
   "bow_tone2": {
     "unicode": "1F647-1F3FC",
@@ -2943,7 +3094,8 @@
       "respect",
       "bend"
     ],
-    "moji": "🙇🏼"
+    "moji": "🙇🏼",
+    "emoji_order": 1526
   },
   "bow_tone3": {
     "unicode": "1F647-1F3FD",
@@ -2962,7 +3114,8 @@
       "respect",
       "bend"
     ],
-    "moji": "🙇🏽"
+    "moji": "🙇🏽",
+    "emoji_order": 1527
   },
   "bow_tone4": {
     "unicode": "1F647-1F3FE",
@@ -2981,7 +3134,8 @@
       "respect",
       "bend"
     ],
-    "moji": "🙇🏾"
+    "moji": "🙇🏾",
+    "emoji_order": 1528
   },
   "bow_tone5": {
     "unicode": "1F647-1F3FF",
@@ -3000,7 +3154,8 @@
       "respect",
       "bend"
     ],
-    "moji": "🙇🏿"
+    "moji": "🙇🏿",
+    "emoji_order": 1529
   },
   "bowling": {
     "unicode": "1F3B3",
@@ -3024,7 +3179,8 @@
       "sport",
       "boys night"
     ],
-    "moji": "🎳"
+    "moji": "🎳",
+    "emoji_order": 475
   },
   "boxing_glove": {
     "unicode": "1F94A",
@@ -3037,7 +3193,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥊"
+    "moji": "🥊",
+    "emoji_order": 10158
   },
   "boy": {
     "unicode": "1F466",
@@ -3055,7 +3212,8 @@
       "baby",
       "diversity"
     ],
-    "moji": "👦"
+    "moji": "👦",
+    "emoji_order": 122
   },
   "boy_tone1": {
     "unicode": "1F466-1F3FB",
@@ -3070,7 +3228,8 @@
       "kid",
       "child"
     ],
-    "moji": "👦🏻"
+    "moji": "👦🏻",
+    "emoji_order": 1430
   },
   "boy_tone2": {
     "unicode": "1F466-1F3FC",
@@ -3085,7 +3244,8 @@
       "kid",
       "child"
     ],
-    "moji": "👦🏼"
+    "moji": "👦🏼",
+    "emoji_order": 1431
   },
   "boy_tone3": {
     "unicode": "1F466-1F3FD",
@@ -3100,7 +3260,8 @@
       "kid",
       "child"
     ],
-    "moji": "👦🏽"
+    "moji": "👦🏽",
+    "emoji_order": 1432
   },
   "boy_tone4": {
     "unicode": "1F466-1F3FE",
@@ -3115,7 +3276,8 @@
       "kid",
       "child"
     ],
-    "moji": "👦🏾"
+    "moji": "👦🏾",
+    "emoji_order": 1433
   },
   "boy_tone5": {
     "unicode": "1F466-1F3FF",
@@ -3130,7 +3292,8 @@
       "kid",
       "child"
     ],
-    "moji": "👦🏿"
+    "moji": "👦🏿",
+    "emoji_order": 1434
   },
   "bread": {
     "unicode": "1F35E",
@@ -3149,7 +3312,8 @@
       "loaf",
       "yeast"
     ],
-    "moji": "🍞"
+    "moji": "🍞",
+    "emoji_order": 371
   },
   "bride_with_veil": {
     "unicode": "1F470",
@@ -3174,7 +3338,8 @@
       "women",
       "diversity"
     ],
-    "moji": "👰"
+    "moji": "👰",
+    "emoji_order": 138
   },
   "bride_with_veil_tone1": {
     "unicode": "1F470-1F3FB",
@@ -3194,7 +3359,8 @@
       "engagement",
       "white"
     ],
-    "moji": "👰🏻"
+    "moji": "👰🏻",
+    "emoji_order": 1505
   },
   "bride_with_veil_tone2": {
     "unicode": "1F470-1F3FC",
@@ -3214,7 +3380,8 @@
       "engagement",
       "white"
     ],
-    "moji": "👰🏼"
+    "moji": "👰🏼",
+    "emoji_order": 1506
   },
   "bride_with_veil_tone3": {
     "unicode": "1F470-1F3FD",
@@ -3234,7 +3401,8 @@
       "engagement",
       "white"
     ],
-    "moji": "👰🏽"
+    "moji": "👰🏽",
+    "emoji_order": 1507
   },
   "bride_with_veil_tone4": {
     "unicode": "1F470-1F3FE",
@@ -3254,7 +3422,8 @@
       "engagement",
       "white"
     ],
-    "moji": "👰🏾"
+    "moji": "👰🏾",
+    "emoji_order": 1508
   },
   "bride_with_veil_tone5": {
     "unicode": "1F470-1F3FF",
@@ -3274,7 +3443,8 @@
       "engagement",
       "white"
     ],
-    "moji": "👰🏿"
+    "moji": "👰🏿",
+    "emoji_order": 1509
   },
   "bridge_at_night": {
     "unicode": "1F309",
@@ -3300,7 +3470,8 @@
       "vacation",
       "goodnight"
     ],
-    "moji": "🌉"
+    "moji": "🌉",
+    "emoji_order": 560
   },
   "briefcase": {
     "unicode": "1F4BC",
@@ -3319,7 +3490,8 @@
       "nutcase",
       "job"
     ],
-    "moji": "💼"
+    "moji": "💼",
+    "emoji_order": 200
   },
   "broken_heart": {
     "unicode": "1F494",
@@ -3338,7 +3510,8 @@
       "symbol",
       "heartbreak"
     ],
-    "moji": "💔"
+    "moji": "💔",
+    "emoji_order": 774
   },
   "bug": {
     "unicode": "1F41B",
@@ -3357,7 +3530,8 @@
       "insects",
       "animal"
     ],
-    "moji": "🐛"
+    "moji": "🐛",
+    "emoji_order": 236
   },
   "bulb": {
     "unicode": "1F4A1",
@@ -3375,7 +3549,8 @@
       "object",
       "science"
     ],
-    "moji": "💡"
+    "moji": "💡",
+    "emoji_order": 631
   },
   "bullettrain_front": {
     "unicode": "1F685",
@@ -3392,7 +3567,8 @@
       "rail",
       "travel"
     ],
-    "moji": "🚅"
+    "moji": "🚅",
+    "emoji_order": 503
   },
   "bullettrain_side": {
     "unicode": "1F684",
@@ -3410,7 +3586,8 @@
       "rail",
       "travel"
     ],
-    "moji": "🚄"
+    "moji": "🚄",
+    "emoji_order": 502
   },
   "burrito": {
     "unicode": "1F32F",
@@ -3424,7 +3601,8 @@
       "food",
       "mexican"
     ],
-    "moji": "🌯"
+    "moji": "🌯",
+    "emoji_order": 383
   },
   "bus": {
     "unicode": "1F68C",
@@ -3444,7 +3622,8 @@
       "public",
       "office"
     ],
-    "moji": "🚌"
+    "moji": "🚌",
+    "emoji_order": 479
   },
   "busstop": {
     "unicode": "1F68F",
@@ -3462,7 +3641,8 @@
       "transport",
       "object"
     ],
-    "moji": "🚏"
+    "moji": "🚏",
+    "emoji_order": 527
   },
   "bust_in_silhouette": {
     "unicode": "1F464",
@@ -3489,7 +3669,8 @@
       "i",
       "people"
     ],
-    "moji": "👤"
+    "moji": "👤",
+    "emoji_order": 118
   },
   "busts_in_silhouette": {
     "unicode": "1F465",
@@ -3514,7 +3695,8 @@
       "relationship",
       "shadow"
     ],
-    "moji": "👥"
+    "moji": "👥",
+    "emoji_order": 119
   },
   "butterfly": {
     "unicode": "1F98B",
@@ -3525,7 +3707,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦋"
+    "moji": "🦋",
+    "emoji_order": 10131
   },
   "cactus": {
     "unicode": "1F335",
@@ -3546,7 +3729,8 @@
       "poke",
       "trees"
     ],
-    "moji": "🌵"
+    "moji": "🌵",
+    "emoji_order": 278
   },
   "cake": {
     "unicode": "1F370",
@@ -3564,7 +3748,8 @@
       "dessert",
       "strawberry"
     ],
-    "moji": "🍰"
+    "moji": "🍰",
+    "emoji_order": 398
   },
   "calendar": {
     "unicode": "1F4C6",
@@ -3579,7 +3764,8 @@
       "object",
       "office"
     ],
-    "moji": "📆"
+    "moji": "📆",
+    "emoji_order": 723
   },
   "calendar_spiral": {
     "unicode": "1F5D3",
@@ -3598,7 +3784,8 @@
       "object",
       "office"
     ],
-    "moji": "🗓"
+    "moji": "🗓",
+    "emoji_order": 724
   },
   "call_me": {
     "unicode": "1F919",
@@ -3611,7 +3798,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤙"
+    "moji": "🤙",
+    "emoji_order": 10118
   },
   "call_me_tone1": {
     "unicode": "1F919-1F3FB",
@@ -3624,7 +3812,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤙🏻"
+    "moji": "🤙🏻",
+    "emoji_order": 10045
   },
   "call_me_tone2": {
     "unicode": "1F919-1F3FC",
@@ -3637,7 +3826,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤙🏼"
+    "moji": "🤙🏼",
+    "emoji_order": 10046
   },
   "call_me_tone3": {
     "unicode": "1F919-1F3FD",
@@ -3650,7 +3840,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤙🏽"
+    "moji": "🤙🏽",
+    "emoji_order": 10047
   },
   "call_me_tone4": {
     "unicode": "1F919-1F3FE",
@@ -3663,7 +3854,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤙🏾"
+    "moji": "🤙🏾",
+    "emoji_order": 10048
   },
   "call_me_tone5": {
     "unicode": "1F919-1F3FF",
@@ -3676,7 +3868,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤙🏿"
+    "moji": "🤙🏿",
+    "emoji_order": 10049
   },
   "calling": {
     "unicode": "1F4F2",
@@ -3693,7 +3886,8 @@
       "phone",
       "selfie"
     ],
-    "moji": "📲"
+    "moji": "📲",
+    "emoji_order": 593
   },
   "camel": {
     "unicode": "1F42B",
@@ -3719,7 +3913,8 @@
       "sex",
       "wildlife"
     ],
-    "moji": "🐫"
+    "moji": "🐫",
+    "emoji_order": 258
   },
   "camera": {
     "unicode": "1F4F7",
@@ -3736,7 +3931,8 @@
       "camera",
       "selfie"
     ],
-    "moji": "📷"
+    "moji": "📷",
+    "emoji_order": 607
   },
   "camera_with_flash": {
     "unicode": "1F4F8",
@@ -3752,7 +3948,8 @@
       "electronics",
       "camera"
     ],
-    "moji": "📸"
+    "moji": "📸",
+    "emoji_order": 608
   },
   "camping": {
     "unicode": "1F3D5",
@@ -3773,7 +3970,8 @@
       "vacation",
       "camp"
     ],
-    "moji": "🏕"
+    "moji": "🏕",
+    "emoji_order": 546
   },
   "cancer": {
     "unicode": "264B",
@@ -3797,7 +3995,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♋"
+    "moji": "♋",
+    "emoji_order": 799
   },
   "candle": {
     "unicode": "1F56F",
@@ -3812,7 +4011,8 @@
       "wax",
       "object"
     ],
-    "moji": "🕯"
+    "moji": "🕯",
+    "emoji_order": 633
   },
   "candy": {
     "unicode": "1F36C",
@@ -3832,7 +4032,8 @@
       "food",
       "halloween"
     ],
-    "moji": "🍬"
+    "moji": "🍬",
+    "emoji_order": 401
   },
   "canoe": {
     "unicode": "1F6F6",
@@ -3845,7 +4046,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🛶"
+    "moji": "🛶",
+    "emoji_order": 10154
   },
   "capital_abcd": {
     "unicode": "1F520",
@@ -3861,7 +4063,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🔠"
+    "moji": "🔠",
+    "emoji_order": 951
   },
   "capricorn": {
     "unicode": "2651",
@@ -3886,7 +4089,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♑"
+    "moji": "♑",
+    "emoji_order": 805
   },
   "card_box": {
     "unicode": "1F5C3",
@@ -3905,7 +4109,8 @@
       "work",
       "office"
     ],
-    "moji": "🗃"
+    "moji": "🗃",
+    "emoji_order": 726
   },
   "card_index": {
     "unicode": "1F4C7",
@@ -3922,7 +4127,8 @@
       "work",
       "office"
     ],
-    "moji": "📇"
+    "moji": "📇",
+    "emoji_order": 725
   },
   "carousel_horse": {
     "unicode": "1F3A0",
@@ -3947,7 +4153,8 @@
       "vacation",
       "roller coaster"
     ],
-    "moji": "🎠"
+    "moji": "🎠",
+    "emoji_order": 534
   },
   "carrot": {
     "unicode": "1F955",
@@ -3958,7 +4165,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥕"
+    "moji": "🥕",
+    "emoji_order": 10142
   },
   "cartwheel": {
     "unicode": "1F938",
@@ -3971,7 +4179,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤸"
+    "moji": "🤸",
+    "emoji_order": 10155
   },
   "cartwheel_tone1": {
     "unicode": "1F938-1F3FB",
@@ -3984,7 +4193,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤸🏻"
+    "moji": "🤸🏻",
+    "emoji_order": 10070
   },
   "cartwheel_tone2": {
     "unicode": "1F938-1F3FC",
@@ -3997,7 +4207,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤸🏼"
+    "moji": "🤸🏼",
+    "emoji_order": 10071
   },
   "cartwheel_tone3": {
     "unicode": "1F938-1F3FD",
@@ -4010,7 +4221,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤸🏽"
+    "moji": "🤸🏽",
+    "emoji_order": 10072
   },
   "cartwheel_tone4": {
     "unicode": "1F938-1F3FE",
@@ -4023,7 +4235,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤸🏾,"
+    "moji": "🤸🏾,",
+    "emoji_order": 10073
   },
   "cartwheel_tone5": {
     "unicode": "1F938-1F3FF",
@@ -4036,7 +4249,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤸🏿"
+    "moji": "🤸🏿",
+    "emoji_order": 10074
   },
   "cat": {
     "unicode": "1F431",
@@ -4053,7 +4267,8 @@
       "vagina",
       "cat"
     ],
-    "moji": "🐱"
+    "moji": "🐱",
+    "emoji_order": 206
   },
   "cat2": {
     "unicode": "1F408",
@@ -4071,7 +4286,8 @@
       "kitten",
       "halloween"
     ],
-    "moji": "🐈"
+    "moji": "🐈",
+    "emoji_order": 272
   },
   "cd": {
     "unicode": "1F4BF",
@@ -4093,7 +4309,8 @@
       "office",
       "electronics"
     ],
-    "moji": "💿"
+    "moji": "💿",
+    "emoji_order": 604
   },
   "chains": {
     "unicode": "26D3",
@@ -4108,7 +4325,8 @@
       "object",
       "tool"
     ],
-    "moji": "⛓"
+    "moji": "⛓",
+    "emoji_order": 652
   },
   "champagne": {
     "unicode": "1F37E",
@@ -4126,7 +4344,8 @@
       "alcohol",
       "parties"
     ],
-    "moji": "🍾"
+    "moji": "🍾",
+    "emoji_order": 412
   },
   "champagne_glass": {
     "unicode": "1F942",
@@ -4139,7 +4358,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥂"
+    "moji": "🥂",
+    "emoji_order": 10147
   },
   "chart": {
     "unicode": "1F4B9",
@@ -4155,7 +4375,8 @@
       "symbol",
       "money"
     ],
-    "moji": "💹"
+    "moji": "💹",
+    "emoji_order": 867
   },
   "chart_with_downwards_trend": {
     "unicode": "1F4C9",
@@ -4170,7 +4391,8 @@
       "work",
       "office"
     ],
-    "moji": "📉"
+    "moji": "📉",
+    "emoji_order": 720
   },
   "chart_with_upwards_trend": {
     "unicode": "1F4C8",
@@ -4185,7 +4407,8 @@
       "work",
       "office"
     ],
-    "moji": "📈"
+    "moji": "📈",
+    "emoji_order": 719
   },
   "checkered_flag": {
     "unicode": "1F3C1",
@@ -4209,7 +4432,8 @@
       "end",
       "object"
     ],
-    "moji": "🏁"
+    "moji": "🏁",
+    "emoji_order": 530
   },
   "cheese": {
     "unicode": "1F9C0",
@@ -4224,7 +4448,8 @@
     "keywords": [
       "food"
     ],
-    "moji": "🧀"
+    "moji": "🧀",
+    "emoji_order": 372
   },
   "cherries": {
     "unicode": "1F352",
@@ -4242,7 +4467,8 @@
       "tree",
       "pit"
     ],
-    "moji": "🍒"
+    "moji": "🍒",
+    "emoji_order": 362
   },
   "cherry_blossom": {
     "unicode": "1F338",
@@ -4261,7 +4487,8 @@
       "tree",
       "tropical"
     ],
-    "moji": "🌸"
+    "moji": "🌸",
+    "emoji_order": 298
   },
   "chestnut": {
     "unicode": "1F330",
@@ -4280,7 +4507,8 @@
       "nature",
       "plant"
     ],
-    "moji": "🌰"
+    "moji": "🌰",
+    "emoji_order": 301
   },
   "chicken": {
     "unicode": "1F414",
@@ -4298,7 +4526,8 @@
       "poultry",
       "livestock"
     ],
-    "moji": "🐔"
+    "moji": "🐔",
+    "emoji_order": 225
   },
   "children_crossing": {
     "unicode": "1F6B8",
@@ -4319,7 +4548,8 @@
       "slow",
       "symbol"
     ],
-    "moji": "🚸"
+    "moji": "🚸",
+    "emoji_order": 863
   },
   "chipmunk": {
     "unicode": "1F43F",
@@ -4334,7 +4564,8 @@
       "nature",
       "wildlife"
     ],
-    "moji": "🐿"
+    "moji": "🐿",
+    "emoji_order": 274
   },
   "chocolate_bar": {
     "unicode": "1F36B",
@@ -4355,7 +4586,8 @@
       "hershey&#039;s",
       "halloween"
     ],
-    "moji": "🍫"
+    "moji": "🍫",
+    "emoji_order": 403
   },
   "christmas_tree": {
     "unicode": "1F384",
@@ -4384,7 +4616,8 @@
       "holidays",
       "trees"
     ],
-    "moji": "🎄"
+    "moji": "🎄",
+    "emoji_order": 279
   },
   "church": {
     "unicode": "26EA",
@@ -4404,7 +4637,8 @@
       "wedding",
       "condolence"
     ],
-    "moji": "⛪"
+    "moji": "⛪",
+    "emoji_order": 586
   },
   "cinema": {
     "unicode": "1F3A6",
@@ -4426,7 +4660,8 @@
       "symbol",
       "camera"
     ],
-    "moji": "🎦"
+    "moji": "🎦",
+    "emoji_order": 893
   },
   "circus_tent": {
     "unicode": "1F3AA",
@@ -4448,7 +4683,8 @@
       "canvas",
       "circus tent"
     ],
-    "moji": "🎪"
+    "moji": "🎪",
+    "emoji_order": 460
   },
   "city_dusk": {
     "unicode": "1F306",
@@ -4472,7 +4708,8 @@
       "places",
       "building"
     ],
-    "moji": "🌆"
+    "moji": "🌆",
+    "emoji_order": 557
   },
   "city_sunset": {
     "unicode": "1F307",
@@ -4500,7 +4737,8 @@
       "sky",
       "vacation"
     ],
-    "moji": "🌇"
+    "moji": "🌇",
+    "emoji_order": 556
   },
   "cityscape": {
     "unicode": "1F3D9",
@@ -4521,7 +4759,8 @@
       "building",
       "vacation"
     ],
-    "moji": "🏙"
+    "moji": "🏙",
+    "emoji_order": 558
   },
   "cl": {
     "unicode": "1F191",
@@ -4540,7 +4779,8 @@
       "symbol",
       "word"
     ],
-    "moji": "🆑"
+    "moji": "🆑",
+    "emoji_order": 834
   },
   "clap": {
     "unicode": "1F44F",
@@ -4567,7 +4807,8 @@
       "good",
       "beautiful"
     ],
-    "moji": "👏"
+    "moji": "👏",
+    "emoji_order": 89
   },
   "clap_tone1": {
     "unicode": "1F44F-1F3FB",
@@ -4588,7 +4829,8 @@
       "encouragement",
       "enthusiasm"
     ],
-    "moji": "👏🏻"
+    "moji": "👏🏻",
+    "emoji_order": 1300
   },
   "clap_tone2": {
     "unicode": "1F44F-1F3FC",
@@ -4609,7 +4851,8 @@
       "encouragement",
       "enthusiasm"
     ],
-    "moji": "👏🏼"
+    "moji": "👏🏼",
+    "emoji_order": 1301
   },
   "clap_tone3": {
     "unicode": "1F44F-1F3FD",
@@ -4630,7 +4873,8 @@
       "encouragement",
       "enthusiasm"
     ],
-    "moji": "👏🏽"
+    "moji": "👏🏽",
+    "emoji_order": 1302
   },
   "clap_tone4": {
     "unicode": "1F44F-1F3FE",
@@ -4651,7 +4895,8 @@
       "encouragement",
       "enthusiasm"
     ],
-    "moji": "👏🏾"
+    "moji": "👏🏾",
+    "emoji_order": 1303
   },
   "clap_tone5": {
     "unicode": "1F44F-1F3FF",
@@ -4672,7 +4917,8 @@
       "encouragement",
       "enthusiasm"
     ],
-    "moji": "👏🏿"
+    "moji": "👏🏿",
+    "emoji_order": 1304
   },
   "clapper": {
     "unicode": "1F3AC",
@@ -4691,7 +4937,8 @@
       "clapboard",
       "take"
     ],
-    "moji": "🎬"
+    "moji": "🎬",
+    "emoji_order": 469
   },
   "classical_building": {
     "unicode": "1F3DB",
@@ -4712,7 +4959,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🏛"
+    "moji": "🏛",
+    "emoji_order": 585
   },
   "clipboard": {
     "unicode": "1F4CB",
@@ -4730,7 +4978,8 @@
       "office",
       "write"
     ],
-    "moji": "📋"
+    "moji": "📋",
+    "emoji_order": 729
   },
   "clock": {
     "unicode": "1F570",
@@ -4746,7 +4995,8 @@
       "time",
       "object"
     ],
-    "moji": "🕰"
+    "moji": "🕰",
+    "emoji_order": 625
   },
   "clock1": {
     "unicode": "1F550",
@@ -4761,7 +5011,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕐"
+    "moji": "🕐",
+    "emoji_order": 1013
   },
   "clock10": {
     "unicode": "1F559",
@@ -4776,7 +5027,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕙"
+    "moji": "🕙",
+    "emoji_order": 1022
   },
   "clock1030": {
     "unicode": "1F565",
@@ -4791,7 +5043,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕥"
+    "moji": "🕥",
+    "emoji_order": 1034
   },
   "clock11": {
     "unicode": "1F55A",
@@ -4806,7 +5059,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕚"
+    "moji": "🕚",
+    "emoji_order": 1023
   },
   "clock1130": {
     "unicode": "1F566",
@@ -4821,7 +5075,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕦"
+    "moji": "🕦",
+    "emoji_order": 1035
   },
   "clock12": {
     "unicode": "1F55B",
@@ -4836,7 +5091,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕛"
+    "moji": "🕛",
+    "emoji_order": 1024
   },
   "clock1230": {
     "unicode": "1F567",
@@ -4851,7 +5107,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕧"
+    "moji": "🕧",
+    "emoji_order": 1036
   },
   "clock130": {
     "unicode": "1F55C",
@@ -4866,7 +5123,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕜"
+    "moji": "🕜",
+    "emoji_order": 1025
   },
   "clock2": {
     "unicode": "1F551",
@@ -4881,7 +5139,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕑"
+    "moji": "🕑",
+    "emoji_order": 1014
   },
   "clock230": {
     "unicode": "1F55D",
@@ -4896,7 +5155,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕝"
+    "moji": "🕝",
+    "emoji_order": 1026
   },
   "clock3": {
     "unicode": "1F552",
@@ -4911,7 +5171,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕒"
+    "moji": "🕒",
+    "emoji_order": 1015
   },
   "clock330": {
     "unicode": "1F55E",
@@ -4926,7 +5187,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕞"
+    "moji": "🕞",
+    "emoji_order": 1027
   },
   "clock4": {
     "unicode": "1F553",
@@ -4941,7 +5203,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕓"
+    "moji": "🕓",
+    "emoji_order": 1016
   },
   "clock430": {
     "unicode": "1F55F",
@@ -4956,7 +5219,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕟"
+    "moji": "🕟",
+    "emoji_order": 1028
   },
   "clock5": {
     "unicode": "1F554",
@@ -4971,7 +5235,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕔"
+    "moji": "🕔",
+    "emoji_order": 1017
   },
   "clock530": {
     "unicode": "1F560",
@@ -4986,7 +5251,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕠"
+    "moji": "🕠",
+    "emoji_order": 1029
   },
   "clock6": {
     "unicode": "1F555",
@@ -5001,7 +5267,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕕"
+    "moji": "🕕",
+    "emoji_order": 1018
   },
   "clock630": {
     "unicode": "1F561",
@@ -5016,7 +5283,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕡"
+    "moji": "🕡",
+    "emoji_order": 1030
   },
   "clock7": {
     "unicode": "1F556",
@@ -5031,7 +5299,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕖"
+    "moji": "🕖",
+    "emoji_order": 1019
   },
   "clock730": {
     "unicode": "1F562",
@@ -5046,7 +5315,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕢"
+    "moji": "🕢",
+    "emoji_order": 1031
   },
   "clock8": {
     "unicode": "1F557",
@@ -5061,7 +5331,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕗"
+    "moji": "🕗",
+    "emoji_order": 1020
   },
   "clock830": {
     "unicode": "1F563",
@@ -5076,7 +5347,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕣"
+    "moji": "🕣",
+    "emoji_order": 1032
   },
   "clock9": {
     "unicode": "1F558",
@@ -5091,7 +5363,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕘"
+    "moji": "🕘",
+    "emoji_order": 1021
   },
   "clock930": {
     "unicode": "1F564",
@@ -5106,7 +5379,8 @@
       "time",
       "symbol"
     ],
-    "moji": "🕤"
+    "moji": "🕤",
+    "emoji_order": 1033
   },
   "closed_book": {
     "unicode": "1F4D5",
@@ -5125,7 +5399,8 @@
       "write",
       "book"
     ],
-    "moji": "📕"
+    "moji": "📕",
+    "emoji_order": 737
   },
   "closed_lock_with_key": {
     "unicode": "1F510",
@@ -5141,7 +5416,8 @@
       "object",
       "lock"
     ],
-    "moji": "🔐"
+    "moji": "🔐",
+    "emoji_order": 756
   },
   "closed_umbrella": {
     "unicode": "1F302",
@@ -5166,7 +5442,8 @@
       "sky",
       "accessories"
     ],
-    "moji": "🌂"
+    "moji": "🌂",
+    "emoji_order": 204
   },
   "cloud": {
     "unicode": "2601",
@@ -5185,7 +5462,8 @@
       "cold",
       "rain"
     ],
-    "moji": "☁"
+    "moji": "☁",
+    "emoji_order": 332
   },
   "cloud_lightning": {
     "unicode": "1F329",
@@ -5205,7 +5483,8 @@
       "cold",
       "rain"
     ],
-    "moji": "🌩"
+    "moji": "🌩",
+    "emoji_order": 335
   },
   "cloud_rain": {
     "unicode": "1F327",
@@ -5226,7 +5505,8 @@
       "cold",
       "rain"
     ],
-    "moji": "🌧"
+    "moji": "🌧",
+    "emoji_order": 333
   },
   "cloud_snow": {
     "unicode": "1F328",
@@ -5246,7 +5526,8 @@
       "cloud",
       "snow"
     ],
-    "moji": "🌨"
+    "moji": "🌨",
+    "emoji_order": 340
   },
   "cloud_tornado": {
     "unicode": "1F32A",
@@ -5265,7 +5546,8 @@
       "sky",
       "cold"
     ],
-    "moji": "🌪"
+    "moji": "🌪",
+    "emoji_order": 345
   },
   "clown": {
     "unicode": "1F921",
@@ -5278,7 +5560,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤡"
+    "moji": "🤡",
+    "emoji_order": 10104
   },
   "clubs": {
     "unicode": "2663",
@@ -5296,7 +5579,8 @@
       "symbol",
       "game"
     ],
-    "moji": "♣"
+    "moji": "♣",
+    "emoji_order": 1006
   },
   "cocktail": {
     "unicode": "1F378",
@@ -5319,7 +5603,8 @@
       "girls night",
       "parties"
     ],
-    "moji": "🍸"
+    "moji": "🍸",
+    "emoji_order": 410
   },
   "coffee": {
     "unicode": "2615",
@@ -5340,7 +5625,8 @@
       "steam",
       "morning"
     ],
-    "moji": "☕"
+    "moji": "☕",
+    "emoji_order": 415
   },
   "coffin": {
     "unicode": "26B0",
@@ -5356,7 +5642,8 @@
       "dead",
       "rip"
     ],
-    "moji": "⚰"
+    "moji": "⚰",
+    "emoji_order": 661
   },
   "cold_sweat": {
     "unicode": "1F630",
@@ -5375,7 +5662,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😰"
+    "moji": "😰",
+    "emoji_order": 53
   },
   "comet": {
     "unicode": "2604",
@@ -5390,7 +5678,8 @@
       "space",
       "sky"
     ],
-    "moji": "☄"
+    "moji": "☄",
+    "emoji_order": 326
   },
   "compression": {
     "unicode": "1F5DC",
@@ -5403,7 +5692,8 @@
     "keywords": [
       "reduce"
     ],
-    "moji": "🗜"
+    "moji": "🗜",
+    "emoji_order": 601
   },
   "computer": {
     "unicode": "1F4BB",
@@ -5420,7 +5710,8 @@
       "work",
       "office"
     ],
-    "moji": "💻"
+    "moji": "💻",
+    "emoji_order": 594
   },
   "confetti_ball": {
     "unicode": "1F38A",
@@ -5448,7 +5739,8 @@
       "boys night",
       "parties"
     ],
-    "moji": "🎊"
+    "moji": "🎊",
+    "emoji_order": 695
   },
   "confounded": {
     "unicode": "1F616",
@@ -5473,7 +5765,8 @@
       "angry",
       "emotion"
     ],
-    "moji": "😖"
+    "moji": "😖",
+    "emoji_order": 46
   },
   "confused": {
     "unicode": "1F615",
@@ -5509,7 +5802,8 @@
       "surprised",
       "emotion"
     ],
-    "moji": "😕"
+    "moji": "😕",
+    "emoji_order": 42
   },
   "congratulations": {
     "unicode": "3297",
@@ -5528,7 +5822,8 @@
       "japan",
       "symbol"
     ],
-    "moji": "㊗"
+    "moji": "㊗",
+    "emoji_order": 827
   },
   "construction": {
     "unicode": "1F6A7",
@@ -5544,7 +5839,8 @@
       "wip",
       "object"
     ],
-    "moji": "🚧"
+    "moji": "🚧",
+    "emoji_order": 525
   },
   "construction_site": {
     "unicode": "1F3D7",
@@ -5563,7 +5859,8 @@
       "building",
       "crane"
     ],
-    "moji": "🏗"
+    "moji": "🏗",
+    "emoji_order": 535
   },
   "construction_worker": {
     "unicode": "1F477",
@@ -5584,7 +5881,8 @@
       "diversity",
       "job"
     ],
-    "moji": "👷"
+    "moji": "👷",
+    "emoji_order": 132
   },
   "construction_worker_tone1": {
     "unicode": "1F477-1F3FB",
@@ -5600,7 +5898,8 @@
       "man",
       "wip"
     ],
-    "moji": "👷🏻"
+    "moji": "👷🏻",
+    "emoji_order": 1480
   },
   "construction_worker_tone2": {
     "unicode": "1F477-1F3FC",
@@ -5616,7 +5915,8 @@
       "man",
       "wip"
     ],
-    "moji": "👷🏼"
+    "moji": "👷🏼",
+    "emoji_order": 1481
   },
   "construction_worker_tone3": {
     "unicode": "1F477-1F3FD",
@@ -5632,7 +5932,8 @@
       "man",
       "wip"
     ],
-    "moji": "👷🏽"
+    "moji": "👷🏽",
+    "emoji_order": 1482
   },
   "construction_worker_tone4": {
     "unicode": "1F477-1F3FE",
@@ -5648,7 +5949,8 @@
       "man",
       "wip"
     ],
-    "moji": "👷🏾"
+    "moji": "👷🏾",
+    "emoji_order": 1483
   },
   "construction_worker_tone5": {
     "unicode": "1F477-1F3FF",
@@ -5664,7 +5966,8 @@
       "man",
       "wip"
     ],
-    "moji": "👷🏿"
+    "moji": "👷🏿",
+    "emoji_order": 1484
   },
   "control_knobs": {
     "unicode": "1F39B",
@@ -5678,7 +5981,8 @@
       "dial",
       "time"
     ],
-    "moji": "🎛"
+    "moji": "🎛",
+    "emoji_order": 621
   },
   "convenience_store": {
     "unicode": "1F3EA",
@@ -5692,7 +5996,8 @@
       "building",
       "places"
     ],
-    "moji": "🏪"
+    "moji": "🏪",
+    "emoji_order": 581
   },
   "cookie": {
     "unicode": "1F36A",
@@ -5713,7 +6018,8 @@
       "sweet",
       "vagina"
     ],
-    "moji": "🍪"
+    "moji": "🍪",
+    "emoji_order": 406
   },
   "cooking": {
     "unicode": "1F373",
@@ -5735,7 +6041,8 @@
       "cooking",
       "utensil"
     ],
-    "moji": "🍳"
+    "moji": "🍳",
+    "emoji_order": 376
   },
   "cool": {
     "unicode": "1F192",
@@ -5750,7 +6057,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🆒"
+    "moji": "🆒",
+    "emoji_order": 899
   },
   "cop": {
     "unicode": "1F46E",
@@ -5773,7 +6081,8 @@
       "job",
       "911"
     ],
-    "moji": "👮"
+    "moji": "👮",
+    "emoji_order": 131
   },
   "cop_tone1": {
     "unicode": "1F46E-1F3FB",
@@ -5790,7 +6099,8 @@
       "man",
       "cop"
     ],
-    "moji": "👮🏻"
+    "moji": "👮🏻",
+    "emoji_order": 1475
   },
   "cop_tone2": {
     "unicode": "1F46E-1F3FC",
@@ -5807,7 +6117,8 @@
       "man",
       "cop"
     ],
-    "moji": "👮🏼"
+    "moji": "👮🏼",
+    "emoji_order": 1476
   },
   "cop_tone3": {
     "unicode": "1F46E-1F3FD",
@@ -5824,7 +6135,8 @@
       "man",
       "cop"
     ],
-    "moji": "👮🏽"
+    "moji": "👮🏽",
+    "emoji_order": 1477
   },
   "cop_tone4": {
     "unicode": "1F46E-1F3FE",
@@ -5841,7 +6153,8 @@
       "man",
       "cop"
     ],
-    "moji": "👮🏾"
+    "moji": "👮🏾",
+    "emoji_order": 1478
   },
   "cop_tone5": {
     "unicode": "1F46E-1F3FF",
@@ -5858,7 +6171,8 @@
       "man",
       "cop"
     ],
-    "moji": "👮🏿"
+    "moji": "👮🏿",
+    "emoji_order": 1479
   },
   "copyright": {
     "moji": "©",
@@ -5873,7 +6187,8 @@
       "ip",
       "license",
       "symbol"
-    ]
+    ],
+    "emoji_order": 965
   },
   "corn": {
     "unicode": "1F33D",
@@ -5899,7 +6214,8 @@
       "ear",
       "vegetables"
     ],
-    "moji": "🌽"
+    "moji": "🌽",
+    "emoji_order": 368
   },
   "couch": {
     "unicode": "1F6CB",
@@ -5922,7 +6238,8 @@
       "relax",
       "object"
     ],
-    "moji": "🛋"
+    "moji": "🛋",
+    "emoji_order": 681
   },
   "couple": {
     "unicode": "1F46B",
@@ -5945,7 +6262,8 @@
       "sex",
       "creationism"
     ],
-    "moji": "👫"
+    "moji": "👫",
+    "emoji_order": 143
   },
   "couple_mm": {
     "unicode": "1F468-2764-1F468",
@@ -5973,7 +6291,8 @@
       "sex",
       "lgbt"
     ],
-    "moji": "👨‍❤️‍👨"
+    "moji": "👨‍❤️‍👨",
+    "emoji_order": 157
   },
   "couple_with_heart": {
     "unicode": "1F491",
@@ -5994,7 +6313,8 @@
       "people",
       "sex"
     ],
-    "moji": "💑"
+    "moji": "💑",
+    "emoji_order": 155
   },
   "couple_ww": {
     "unicode": "1F469-2764-1F469",
@@ -6021,7 +6341,8 @@
       "sex",
       "lgbt"
     ],
-    "moji": "👩‍❤️‍👩"
+    "moji": "👩‍❤️‍👩",
+    "emoji_order": 156
   },
   "couplekiss": {
     "unicode": "1F48F",
@@ -6040,7 +6361,8 @@
       "people",
       "sex"
     ],
-    "moji": "💏"
+    "moji": "💏",
+    "emoji_order": 158
   },
   "cow": {
     "unicode": "1F42E",
@@ -6055,7 +6377,8 @@
       "beef",
       "ox"
     ],
-    "moji": "🐮"
+    "moji": "🐮",
+    "emoji_order": 215
   },
   "cow2": {
     "unicode": "1F404",
@@ -6076,7 +6399,8 @@
       "bessie",
       "moo"
     ],
-    "moji": "🐄"
+    "moji": "🐄",
+    "emoji_order": 256
   },
   "cowboy": {
     "unicode": "1F920",
@@ -6089,7 +6413,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤠"
+    "moji": "🤠",
+    "emoji_order": 10103
   },
   "crab": {
     "unicode": "1F980",
@@ -6103,7 +6428,8 @@
       "tropical",
       "animal"
     ],
-    "moji": "🦀"
+    "moji": "🦀",
+    "emoji_order": 242
   },
   "crayon": {
     "unicode": "1F58D",
@@ -6123,7 +6449,8 @@
       "object",
       "office"
     ],
-    "moji": "🖍"
+    "moji": "🖍",
+    "emoji_order": 765
   },
   "credit_card": {
     "unicode": "1F4B3",
@@ -6152,7 +6479,8 @@
       "object",
       "boys night"
     ],
-    "moji": "💳"
+    "moji": "💳",
+    "emoji_order": 642
   },
   "crescent_moon": {
     "unicode": "1F319",
@@ -6173,7 +6501,8 @@
       "space",
       "goodnight"
     ],
-    "moji": "🌙"
+    "moji": "🌙",
+    "emoji_order": 321
   },
   "cricket": {
     "unicode": "1F3CF",
@@ -6190,7 +6519,8 @@
       "sport",
       "cricket"
     ],
-    "moji": "🏏"
+    "moji": "🏏",
+    "emoji_order": 433
   },
   "crocodile": {
     "unicode": "1F40A",
@@ -6211,7 +6541,8 @@
       "wildlife",
       "reptile"
     ],
-    "moji": "🐊"
+    "moji": "🐊",
+    "emoji_order": 251
   },
   "croissant": {
     "unicode": "1F950",
@@ -6222,7 +6553,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥐"
+    "moji": "🥐",
+    "emoji_order": 10137
   },
   "cross": {
     "unicode": "271D",
@@ -6239,7 +6571,8 @@
       "symbol",
       "christian"
     ],
-    "moji": "✝"
+    "moji": "✝",
+    "emoji_order": 785
   },
   "crossed_flags": {
     "unicode": "1F38C",
@@ -6253,7 +6586,8 @@
       "japan",
       "object"
     ],
-    "moji": "🎌"
+    "moji": "🎌",
+    "emoji_order": 699
   },
   "crossed_swords": {
     "unicode": "2694",
@@ -6267,7 +6601,8 @@
       "object",
       "weapon"
     ],
-    "moji": "⚔"
+    "moji": "⚔",
+    "emoji_order": 657
   },
   "crown": {
     "unicode": "1F451",
@@ -6286,7 +6621,8 @@
       "gem",
       "accessories"
     ],
-    "moji": "👑"
+    "moji": "👑",
+    "emoji_order": 195
   },
   "cruise_ship": {
     "unicode": "1F6F3",
@@ -6305,7 +6641,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🛳"
+    "moji": "🛳",
+    "emoji_order": 520
   },
   "cry": {
     "unicode": "1F622",
@@ -6332,7 +6669,8 @@
       "rip",
       "heartbreak"
     ],
-    "moji": "😢"
+    "moji": "😢",
+    "emoji_order": 57
   },
   "crying_cat_face": {
     "unicode": "1F63F",
@@ -6356,7 +6694,8 @@
       "somber",
       "hurt"
     ],
-    "moji": "😿"
+    "moji": "😿",
+    "emoji_order": 86
   },
   "crystal_ball": {
     "unicode": "1F52E",
@@ -6372,7 +6711,8 @@
       "object",
       "ball"
     ],
-    "moji": "🔮"
+    "moji": "🔮",
+    "emoji_order": 664
   },
   "cucumber": {
     "unicode": "1F952",
@@ -6383,7 +6723,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥒"
+    "moji": "🥒",
+    "emoji_order": 10139
   },
   "cupid": {
     "unicode": "1F498",
@@ -6401,7 +6742,8 @@
       "valentines",
       "symbol"
     ],
-    "moji": "💘"
+    "moji": "💘",
+    "emoji_order": 781
   },
   "curly_loop": {
     "unicode": "27B0",
@@ -6415,7 +6757,8 @@
       "scribble",
       "symbol"
     ],
-    "moji": "➰"
+    "moji": "➰",
+    "emoji_order": 956
   },
   "currency_exchange": {
     "unicode": "1F4B1",
@@ -6431,7 +6774,8 @@
       "travel",
       "symbol"
     ],
-    "moji": "💱"
+    "moji": "💱",
+    "emoji_order": 964
   },
   "curry": {
     "unicode": "1F35B",
@@ -6451,7 +6795,8 @@
       "flavor",
       "meal"
     ],
-    "moji": "🍛"
+    "moji": "🍛",
+    "emoji_order": 389
   },
   "custard": {
     "unicode": "1F36E",
@@ -6473,7 +6818,8 @@
       "brûlée",
       "french"
     ],
-    "moji": "🍮"
+    "moji": "🍮",
+    "emoji_order": 400
   },
   "customs": {
     "unicode": "1F6C3",
@@ -6495,7 +6841,8 @@
       "government",
       "symbol"
     ],
-    "moji": "🛃"
+    "moji": "🛃",
+    "emoji_order": 880
   },
   "cyclone": {
     "moji": "🌀",
@@ -6518,7 +6865,8 @@
       "ocean",
       "symbol",
       "drugs"
-    ]
+    ],
+    "emoji_order": 873
   },
   "dagger": {
     "unicode": "1F5E1",
@@ -6536,7 +6884,8 @@
       "object",
       "weapon"
     ],
-    "moji": "🗡"
+    "moji": "🗡",
+    "emoji_order": 656
   },
   "dancer": {
     "unicode": "1F483",
@@ -6568,7 +6917,8 @@
       "diversity",
       "girls night"
     ],
-    "moji": "💃"
+    "moji": "💃",
+    "emoji_order": 141
   },
   "dancer_tone1": {
     "unicode": "1F483-1F3FB",
@@ -6593,7 +6943,8 @@
       "cha cha",
       "music"
     ],
-    "moji": "💃🏻"
+    "moji": "💃🏻",
+    "emoji_order": 1520
   },
   "dancer_tone2": {
     "unicode": "1F483-1F3FC",
@@ -6618,7 +6969,8 @@
       "cha cha",
       "music"
     ],
-    "moji": "💃🏼"
+    "moji": "💃🏼",
+    "emoji_order": 1521
   },
   "dancer_tone3": {
     "unicode": "1F483-1F3FD",
@@ -6643,7 +6995,8 @@
       "cha cha",
       "music"
     ],
-    "moji": "💃🏽"
+    "moji": "💃🏽",
+    "emoji_order": 1522
   },
   "dancer_tone4": {
     "unicode": "1F483-1F3FE",
@@ -6668,7 +7021,8 @@
       "cha cha",
       "music"
     ],
-    "moji": "💃🏾"
+    "moji": "💃🏾",
+    "emoji_order": 1523
   },
   "dancer_tone5": {
     "unicode": "1F483-1F3FF",
@@ -6693,7 +7047,8 @@
       "cha cha",
       "music"
     ],
-    "moji": "💃🏿"
+    "moji": "💃🏿",
+    "emoji_order": 1524
   },
   "dancers": {
     "unicode": "1F46F",
@@ -6721,7 +7076,8 @@
       "parties",
       "dance"
     ],
-    "moji": "👯"
+    "moji": "👯",
+    "emoji_order": 142
   },
   "dango": {
     "unicode": "1F361",
@@ -6740,7 +7096,8 @@
       "balls",
       "skewer"
     ],
-    "moji": "🍡"
+    "moji": "🍡",
+    "emoji_order": 394
   },
   "dark_sunglasses": {
     "unicode": "1F576",
@@ -6757,7 +7114,8 @@
       "glasses",
       "accessories"
     ],
-    "moji": "🕶"
+    "moji": "🕶",
+    "emoji_order": 202
   },
   "dart": {
     "unicode": "1F3AF",
@@ -6780,7 +7138,8 @@
       "sport",
       "boys night"
     ],
-    "moji": "🎯"
+    "moji": "🎯",
+    "emoji_order": 472
   },
   "dash": {
     "unicode": "1F4A8",
@@ -6799,7 +7158,8 @@
       "cold",
       "smoking"
     ],
-    "moji": "💨"
+    "moji": "💨",
+    "emoji_order": 344
   },
   "date": {
     "unicode": "1F4C5",
@@ -6815,7 +7175,8 @@
       "object",
       "office"
     ],
-    "moji": "📅"
+    "moji": "📅",
+    "emoji_order": 722
   },
   "deciduous_tree": {
     "unicode": "1F333",
@@ -6836,7 +7197,8 @@
       "camp",
       "trees"
     ],
-    "moji": "🌳"
+    "moji": "🌳",
+    "emoji_order": 281
   },
   "deer": {
     "unicode": "1F98C",
@@ -6847,7 +7209,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦌"
+    "moji": "🦌",
+    "emoji_order": 10132
   },
   "department_store": {
     "unicode": "1F3EC",
@@ -6868,7 +7231,8 @@
       "merchandise",
       "places"
     ],
-    "moji": "🏬"
+    "moji": "🏬",
+    "emoji_order": 575
   },
   "desert": {
     "unicode": "1F3DC",
@@ -6889,7 +7253,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🏜"
+    "moji": "🏜",
+    "emoji_order": 553
   },
   "desktop": {
     "unicode": "1F5A5",
@@ -6906,7 +7271,8 @@
       "electronics",
       "work"
     ],
-    "moji": "🖥"
+    "moji": "🖥",
+    "emoji_order": 596
   },
   "diamond_shape_with_a_dot_inside": {
     "unicode": "1F4A0",
@@ -6926,7 +7292,8 @@
       "adorable",
       "symbol"
     ],
-    "moji": "💠"
+    "moji": "💠",
+    "emoji_order": 872
   },
   "diamonds": {
     "unicode": "2666",
@@ -6945,7 +7312,8 @@
       "symbol",
       "game"
     ],
-    "moji": "♦"
+    "moji": "♦",
+    "emoji_order": 1008
   },
   "disappointed": {
     "unicode": "1F61E",
@@ -6975,7 +7343,8 @@
       "tired",
       "emotion"
     ],
-    "moji": "😞"
+    "moji": "😞",
+    "emoji_order": 37
   },
   "disappointed_relieved": {
     "unicode": "1F625",
@@ -6998,7 +7367,8 @@
       "cry",
       "emotion"
     ],
-    "moji": "😥"
+    "moji": "😥",
+    "emoji_order": 58
   },
   "dividers": {
     "unicode": "1F5C2",
@@ -7016,7 +7386,8 @@
       "work",
       "office"
     ],
-    "moji": "🗂"
+    "moji": "🗂",
+    "emoji_order": 733
   },
   "dizzy": {
     "unicode": "1F4AB",
@@ -7038,7 +7409,8 @@
       "starburst",
       "symbol"
     ],
-    "moji": "💫"
+    "moji": "💫",
+    "emoji_order": 324
   },
   "dizzy_face": {
     "unicode": "1F635",
@@ -7070,7 +7442,8 @@
       "emotion",
       "omg"
     ],
-    "moji": "😵"
+    "moji": "😵",
+    "emoji_order": 62
   },
   "do_not_litter": {
     "unicode": "1F6AF",
@@ -7090,7 +7463,8 @@
       "can",
       "symbol"
     ],
-    "moji": "🚯"
+    "moji": "🚯",
+    "emoji_order": 845
   },
   "dog": {
     "unicode": "1F436",
@@ -7108,7 +7482,8 @@
       "dog",
       "pug"
     ],
-    "moji": "🐶"
+    "moji": "🐶",
+    "emoji_order": 205
   },
   "dog2": {
     "unicode": "1F415",
@@ -7131,7 +7506,8 @@
       "fido",
       "pug"
     ],
-    "moji": "🐕"
+    "moji": "🐕",
+    "emoji_order": 270
   },
   "dollar": {
     "unicode": "1F4B5",
@@ -7154,7 +7530,8 @@
       "cash",
       "bills"
     ],
-    "moji": "💵"
+    "moji": "💵",
+    "emoji_order": 637
   },
   "dolls": {
     "unicode": "1F38E",
@@ -7181,7 +7558,8 @@
       "royal",
       "people"
     ],
-    "moji": "🎎"
+    "moji": "🎎",
+    "emoji_order": 697
   },
   "dolphin": {
     "unicode": "1F42C",
@@ -7202,7 +7580,8 @@
       "wildlife",
       "tropical"
     ],
-    "moji": "🐬"
+    "moji": "🐬",
+    "emoji_order": 248
   },
   "door": {
     "unicode": "1F6AA",
@@ -7222,7 +7601,8 @@
       "enter",
       "object"
     ],
-    "moji": "🚪"
+    "moji": "🚪",
+    "emoji_order": 684
   },
   "doughnut": {
     "unicode": "1F369",
@@ -7246,7 +7626,8 @@
       "police",
       "homer"
     ],
-    "moji": "🍩"
+    "moji": "🍩",
+    "emoji_order": 405
   },
   "dove": {
     "unicode": "1F54A",
@@ -7263,7 +7644,8 @@
       "bird",
       "animal"
     ],
-    "moji": "🕊"
+    "moji": "🕊",
+    "emoji_order": 269
   },
   "dragon": {
     "unicode": "1F409",
@@ -7285,7 +7667,8 @@
       "roar",
       "reptile"
     ],
-    "moji": "🐉"
+    "moji": "🐉",
+    "emoji_order": 276
   },
   "dragon_face": {
     "unicode": "1F432",
@@ -7309,7 +7692,8 @@
       "monster",
       "reptile"
     ],
-    "moji": "🐲"
+    "moji": "🐲",
+    "emoji_order": 277
   },
   "dress": {
     "unicode": "1F457",
@@ -7326,7 +7710,8 @@
       "sexy",
       "girls night"
     ],
-    "moji": "👗"
+    "moji": "👗",
+    "emoji_order": 180
   },
   "dromedary_camel": {
     "unicode": "1F42A",
@@ -7351,7 +7736,8 @@
       "sex",
       "wildlife"
     ],
-    "moji": "🐪"
+    "moji": "🐪",
+    "emoji_order": 257
   },
   "drooling_face": {
     "unicode": "1F924",
@@ -7364,7 +7750,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤤"
+    "moji": "🤤",
+    "emoji_order": 10107
   },
   "droplet": {
     "unicode": "1F4A7",
@@ -7392,7 +7779,8 @@
       "weather",
       "sky"
     ],
-    "moji": "💧"
+    "moji": "💧",
+    "emoji_order": 349
   },
   "drum": {
     "unicode": "1F941",
@@ -7405,7 +7793,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥁"
+    "moji": "🥁",
+    "emoji_order": 10167
   },
   "duck": {
     "unicode": "1F986",
@@ -7416,7 +7805,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦆"
+    "moji": "🦆",
+    "emoji_order": 10126
   },
   "dvd": {
     "unicode": "1F4C0",
@@ -7432,7 +7822,8 @@
       "disk",
       "electronics"
     ],
-    "moji": "📀"
+    "moji": "📀",
+    "emoji_order": 605
   },
   "e-mail": {
     "unicode": "1F4E7",
@@ -7449,7 +7840,8 @@
       "inbox",
       "office"
     ],
-    "moji": "📧"
+    "moji": "📧",
+    "emoji_order": 704
   },
   "eagle": {
     "unicode": "1F985",
@@ -7460,7 +7852,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦅"
+    "moji": "🦅",
+    "emoji_order": 10125
   },
   "ear": {
     "unicode": "1F442",
@@ -7478,7 +7871,8 @@
       "body",
       "diversity"
     ],
-    "moji": "👂"
+    "moji": "👂",
+    "emoji_order": 114
   },
   "ear_of_rice": {
     "unicode": "1F33E",
@@ -7497,7 +7891,8 @@
       "seed",
       "leaf"
     ],
-    "moji": "🌾"
+    "moji": "🌾",
+    "emoji_order": 292
   },
   "ear_tone1": {
     "unicode": "1F442-1F3FB",
@@ -7512,7 +7907,8 @@
       "listen",
       "sound"
     ],
-    "moji": "👂🏻"
+    "moji": "👂🏻",
+    "emoji_order": 1415
   },
   "ear_tone2": {
     "unicode": "1F442-1F3FC",
@@ -7527,7 +7923,8 @@
       "listen",
       "sound"
     ],
-    "moji": "👂🏼"
+    "moji": "👂🏼",
+    "emoji_order": 1416
   },
   "ear_tone3": {
     "unicode": "1F442-1F3FD",
@@ -7542,7 +7939,8 @@
       "listen",
       "sound"
     ],
-    "moji": "👂🏽"
+    "moji": "👂🏽",
+    "emoji_order": 1417
   },
   "ear_tone4": {
     "unicode": "1F442-1F3FE",
@@ -7557,7 +7955,8 @@
       "listen",
       "sound"
     ],
-    "moji": "👂🏾"
+    "moji": "👂🏾",
+    "emoji_order": 1418
   },
   "ear_tone5": {
     "unicode": "1F442-1F3FF",
@@ -7572,7 +7971,8 @@
       "listen",
       "sound"
     ],
-    "moji": "👂🏿"
+    "moji": "👂🏿",
+    "emoji_order": 1419
   },
   "earth_africa": {
     "unicode": "1F30D",
@@ -7595,7 +7995,8 @@
       "map",
       "vacation"
     ],
-    "moji": "🌍"
+    "moji": "🌍",
+    "emoji_order": 306
   },
   "earth_americas": {
     "unicode": "1F30E",
@@ -7621,7 +8022,8 @@
       "map",
       "vacation"
     ],
-    "moji": "🌎"
+    "moji": "🌎",
+    "emoji_order": 305
   },
   "earth_asia": {
     "unicode": "1F30F",
@@ -7645,7 +8047,8 @@
       "map",
       "vacation"
     ],
-    "moji": "🌏"
+    "moji": "🌏",
+    "emoji_order": 307
   },
   "egg": {
     "unicode": "1F95A",
@@ -7656,7 +8059,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥚"
+    "moji": "🥚",
+    "emoji_order": 10170
   },
   "eggplant": {
     "unicode": "1F346",
@@ -7677,7 +8081,8 @@
       "penis",
       "vegetables"
     ],
-    "moji": "🍆"
+    "moji": "🍆",
+    "emoji_order": 366
   },
   "eight": {
     "moji": "8️⃣",
@@ -7697,7 +8102,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 910
   },
   "eight_pointed_black_star": {
     "unicode": "2734",
@@ -7712,7 +8118,8 @@
     "keywords": [
       "symbol"
     ],
-    "moji": "✴"
+    "moji": "✴",
+    "emoji_order": 821
   },
   "eight_spoked_asterisk": {
     "unicode": "2733",
@@ -7730,7 +8137,8 @@
       "star",
       "symbol"
     ],
-    "moji": "✳"
+    "moji": "✳",
+    "emoji_order": 869
   },
   "eject": {
     "unicode": "23CF",
@@ -7745,7 +8153,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "⏏"
+    "moji": "⏏",
+    "emoji_order": 10101
   },
   "electric_plug": {
     "unicode": "1F50C",
@@ -7760,7 +8169,8 @@
       "power",
       "electronics"
     ],
-    "moji": "🔌"
+    "moji": "🔌",
+    "emoji_order": 630
   },
   "elephant": {
     "unicode": "1F418",
@@ -7777,7 +8187,8 @@
       "thailand",
       "wildlife"
     ],
-    "moji": "🐘"
+    "moji": "🐘",
+    "emoji_order": 259
   },
   "end": {
     "unicode": "1F51A",
@@ -7792,7 +8203,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🔚"
+    "moji": "🔚",
+    "emoji_order": 968
   },
   "envelope": {
     "unicode": "2709",
@@ -7813,7 +8225,8 @@
       "office",
       "write"
     ],
-    "moji": "✉"
+    "moji": "✉",
+    "emoji_order": 701
   },
   "envelope_with_arrow": {
     "unicode": "1F4E9",
@@ -7828,7 +8241,8 @@
       "object",
       "office"
     ],
-    "moji": "📩"
+    "moji": "📩",
+    "emoji_order": 702
   },
   "euro": {
     "unicode": "1F4B6",
@@ -7849,7 +8263,8 @@
       "cash",
       "bills"
     ],
-    "moji": "💶"
+    "moji": "💶",
+    "emoji_order": 639
   },
   "european_castle": {
     "unicode": "1F3F0",
@@ -7884,7 +8299,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🏰"
+    "moji": "🏰",
+    "emoji_order": 567
   },
   "european_post_office": {
     "unicode": "1F3E4",
@@ -7899,7 +8315,8 @@
       "places",
       "post office"
     ],
-    "moji": "🏤"
+    "moji": "🏤",
+    "emoji_order": 577
   },
   "evergreen_tree": {
     "unicode": "1F332",
@@ -7920,7 +8337,8 @@
       "camp",
       "trees"
     ],
-    "moji": "🌲"
+    "moji": "🌲",
+    "emoji_order": 280
   },
   "exclamation": {
     "unicode": "2757",
@@ -7937,7 +8355,8 @@
       "symbol",
       "punctuation"
     ],
-    "moji": "❗"
+    "moji": "❗",
+    "emoji_order": 850
   },
   "expressionless": {
     "unicode": "1F611",
@@ -7964,7 +8383,8 @@
       "neutral",
       "emotion"
     ],
-    "moji": "😑"
+    "moji": "😑",
+    "emoji_order": 32
   },
   "eye": {
     "unicode": "1F441",
@@ -7981,7 +8401,8 @@
       "body",
       "eyes"
     ],
-    "moji": "👁"
+    "moji": "👁",
+    "emoji_order": 116
   },
   "eye_in_speech_bubble": {
     "unicode": "1F441-1F5E8",
@@ -7999,7 +8420,8 @@
       "eyes",
       "talk"
     ],
-    "moji": "👁‍🗨"
+    "moji": "👁‍🗨",
+    "emoji_order": 1037
   },
   "eyeglasses": {
     "unicode": "1F453",
@@ -8028,7 +8450,8 @@
       "contacts",
       "glasses"
     ],
-    "moji": "👓"
+    "moji": "👓",
+    "emoji_order": 201
   },
   "eyes": {
     "unicode": "1F440",
@@ -8046,7 +8469,8 @@
       "body",
       "eyes"
     ],
-    "moji": "👀"
+    "moji": "👀",
+    "emoji_order": 117
   },
   "face_palm": {
     "unicode": "1F926",
@@ -8059,7 +8483,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤦"
+    "moji": "🤦",
+    "emoji_order": 10113
   },
   "face_palm_tone1": {
     "unicode": "1F926-1F3FB",
@@ -8072,7 +8497,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤦🏻"
+    "moji": "🤦🏻",
+    "emoji_order": 10020
   },
   "face_palm_tone2": {
     "unicode": "1F926-1F3FC",
@@ -8085,7 +8511,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤦🏼"
+    "moji": "🤦🏼",
+    "emoji_order": 10021
   },
   "face_palm_tone3": {
     "unicode": "1F926-1F3FD",
@@ -8098,7 +8525,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤦🏽"
+    "moji": "🤦🏽",
+    "emoji_order": 10022
   },
   "face_palm_tone4": {
     "unicode": "1F926-1F3FE",
@@ -8111,7 +8539,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤦🏾"
+    "moji": "🤦🏾",
+    "emoji_order": 10023
   },
   "face_palm_tone5": {
     "unicode": "1F926-1F3FF",
@@ -8124,7 +8553,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤦🏿"
+    "moji": "🤦🏿",
+    "emoji_order": 10024
   },
   "factory": {
     "unicode": "1F3ED",
@@ -8140,7 +8570,8 @@
       "travel",
       "steam"
     ],
-    "moji": "🏭"
+    "moji": "🏭",
+    "emoji_order": 538
   },
   "fallen_leaf": {
     "unicode": "1F342",
@@ -8161,7 +8592,8 @@
       "deciduous",
       "autumn"
     ],
-    "moji": "🍂"
+    "moji": "🍂",
+    "emoji_order": 290
   },
   "family": {
     "unicode": "1F46A",
@@ -8187,7 +8619,8 @@
       "people",
       "baby"
     ],
-    "moji": "👪"
+    "moji": "👪",
+    "emoji_order": 161
   },
   "family_mmb": {
     "unicode": "1F468-1F468-1F466",
@@ -8216,7 +8649,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👨‍👨‍👦"
+    "moji": "👨‍👨‍👦",
+    "emoji_order": 171
   },
   "family_mmbb": {
     "unicode": "1F468-1F468-1F466-1F466",
@@ -8245,7 +8679,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👨‍👨‍👦‍👦"
+    "moji": "👨‍👨‍👦‍👦",
+    "emoji_order": 174
   },
   "family_mmg": {
     "unicode": "1F468-1F468-1F467",
@@ -8274,7 +8709,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👨‍👨‍👧"
+    "moji": "👨‍👨‍👧",
+    "emoji_order": 172
   },
   "family_mmgb": {
     "unicode": "1F468-1F468-1F467-1F466",
@@ -8304,7 +8740,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👨‍👨‍👧‍👦"
+    "moji": "👨‍👨‍👧‍👦",
+    "emoji_order": 173
   },
   "family_mmgg": {
     "unicode": "1F468-1F468-1F467-1F467",
@@ -8333,7 +8770,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👨‍👨‍👧‍👧"
+    "moji": "👨‍👨‍👧‍👧",
+    "emoji_order": 175
   },
   "family_mwbb": {
     "unicode": "1F468-1F469-1F466-1F466",
@@ -8361,7 +8799,8 @@
       "family",
       "baby"
     ],
-    "moji": "👨‍👩‍👦‍👦"
+    "moji": "👨‍👩‍👦‍👦",
+    "emoji_order": 164
   },
   "family_mwg": {
     "unicode": "1F468-1F469-1F467",
@@ -8390,7 +8829,8 @@
       "family",
       "baby"
     ],
-    "moji": "👨‍👩‍👧"
+    "moji": "👨‍👩‍👧",
+    "emoji_order": 162
   },
   "family_mwgb": {
     "unicode": "1F468-1F469-1F467-1F466",
@@ -8419,7 +8859,8 @@
       "family",
       "baby"
     ],
-    "moji": "👨‍👩‍👧‍👦"
+    "moji": "👨‍👩‍👧‍👦",
+    "emoji_order": 163
   },
   "family_mwgg": {
     "unicode": "1F468-1F469-1F467-1F467",
@@ -8447,7 +8888,8 @@
       "family",
       "baby"
     ],
-    "moji": "👨‍👩‍👧‍👧"
+    "moji": "👨‍👩‍👧‍👧",
+    "emoji_order": 165
   },
   "family_wwb": {
     "unicode": "1F469-1F469-1F466",
@@ -8477,7 +8919,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👩‍👩‍👦"
+    "moji": "👩‍👩‍👦",
+    "emoji_order": 166
   },
   "family_wwbb": {
     "unicode": "1F469-1F469-1F466-1F466",
@@ -8507,7 +8950,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👩‍👩‍👦‍👦"
+    "moji": "👩‍👩‍👦‍👦",
+    "emoji_order": 169
   },
   "family_wwg": {
     "unicode": "1F469-1F469-1F467",
@@ -8537,7 +8981,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👩‍👩‍👧"
+    "moji": "👩‍👩‍👧",
+    "emoji_order": 167
   },
   "family_wwgb": {
     "unicode": "1F469-1F469-1F467-1F466",
@@ -8568,7 +9013,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👩‍👩‍👧‍👦"
+    "moji": "👩‍👩‍👧‍👦",
+    "emoji_order": 168
   },
   "family_wwgg": {
     "unicode": "1F469-1F469-1F467-1F467",
@@ -8598,7 +9044,8 @@
       "baby",
       "lgbt"
     ],
-    "moji": "👩‍👩‍👧‍👧"
+    "moji": "👩‍👩‍👧‍👧",
+    "emoji_order": 170
   },
   "fast_forward": {
     "unicode": "23E9",
@@ -8613,7 +9060,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "⏩"
+    "moji": "⏩",
+    "emoji_order": 921
   },
   "fax": {
     "unicode": "1F4E0",
@@ -8630,7 +9078,8 @@
       "work",
       "office"
     ],
-    "moji": "📠"
+    "moji": "📠",
+    "emoji_order": 616
   },
   "fearful": {
     "unicode": "1F628",
@@ -8653,7 +9102,8 @@
       "surprised",
       "emotion"
     ],
-    "moji": "😨"
+    "moji": "😨",
+    "emoji_order": 52
   },
   "feet": {
     "unicode": "1F43E",
@@ -8682,7 +9132,8 @@
       "feet",
       "pawsteps"
     ],
-    "moji": "🐾"
+    "moji": "🐾",
+    "emoji_order": 275
   },
   "fencer": {
     "unicode": "1F93A",
@@ -8695,7 +9146,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤺"
+    "moji": "🤺",
+    "emoji_order": 10163
   },
   "ferris_wheel": {
     "unicode": "1F3A1",
@@ -8720,7 +9172,8 @@
       "vacation",
       "ferris wheel"
     ],
-    "moji": "🎡"
+    "moji": "🎡",
+    "emoji_order": 532
   },
   "ferry": {
     "unicode": "26F4",
@@ -8737,7 +9190,8 @@
       "transportation",
       "vacation"
     ],
-    "moji": "⛴"
+    "moji": "⛴",
+    "emoji_order": 519
   },
   "field_hockey": {
     "unicode": "1F3D1",
@@ -8752,7 +9206,8 @@
       "sport",
       "hockey"
     ],
-    "moji": "🏑"
+    "moji": "🏑",
+    "emoji_order": 432
   },
   "file_cabinet": {
     "unicode": "1F5C4",
@@ -8770,7 +9225,8 @@
       "object",
       "work"
     ],
-    "moji": "🗄"
+    "moji": "🗄",
+    "emoji_order": 728
   },
   "file_folder": {
     "unicode": "1F4C1",
@@ -8785,7 +9241,8 @@
       "work",
       "office"
     ],
-    "moji": "📁"
+    "moji": "📁",
+    "emoji_order": 731
   },
   "film_frames": {
     "unicode": "1F39E",
@@ -8805,7 +9262,8 @@
       "object",
       "camera"
     ],
-    "moji": "🎞"
+    "moji": "🎞",
+    "emoji_order": 612
   },
   "fingers_crossed": {
     "unicode": "1F91E",
@@ -8818,7 +9276,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤞"
+    "moji": "🤞",
+    "emoji_order": 10123
   },
   "fingers_crossed_tone1": {
     "unicode": "1F91E-1F3FB",
@@ -8831,7 +9290,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤞🏻"
+    "moji": "🤞🏻",
+    "emoji_order": 10040
   },
   "fingers_crossed_tone2": {
     "unicode": "1F91E-1F3FC",
@@ -8844,7 +9304,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤞🏼"
+    "moji": "🤞🏼",
+    "emoji_order": 10041
   },
   "fingers_crossed_tone3": {
     "unicode": "1F91E-1F3FD",
@@ -8857,7 +9318,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤞🏽"
+    "moji": "🤞🏽",
+    "emoji_order": 10042
   },
   "fingers_crossed_tone4": {
     "unicode": "1F91E-1F3FE",
@@ -8870,7 +9332,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤞🏾"
+    "moji": "🤞🏾",
+    "emoji_order": 10043
   },
   "fingers_crossed_tone5": {
     "unicode": "1F91E-1F3FF",
@@ -8883,7 +9346,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤞🏿"
+    "moji": "🤞🏿",
+    "emoji_order": 10044
   },
   "fire": {
     "unicode": "1F525",
@@ -8901,7 +9365,8 @@
       "flame",
       "wth"
     ],
-    "moji": "🔥"
+    "moji": "🔥",
+    "emoji_order": 337
   },
   "fire_engine": {
     "unicode": "1F692",
@@ -8923,7 +9388,8 @@
       "medical",
       "911"
     ],
-    "moji": "🚒"
+    "moji": "🚒",
+    "emoji_order": 484
   },
   "fireworks": {
     "unicode": "1F386",
@@ -8950,7 +9416,8 @@
       "excitement",
       "parties"
     ],
-    "moji": "🎆"
+    "moji": "🎆",
+    "emoji_order": 564
   },
   "first_place": {
     "unicode": "1F947",
@@ -8963,7 +9430,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥇"
+    "moji": "🥇",
+    "emoji_order": 10164
   },
   "first_quarter_moon": {
     "unicode": "1F313",
@@ -8984,7 +9452,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌓"
+    "moji": "🌓",
+    "emoji_order": 314
   },
   "first_quarter_moon_with_face": {
     "unicode": "1F31B",
@@ -9007,7 +9476,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌛"
+    "moji": "🌛",
+    "emoji_order": 318
   },
   "fish": {
     "unicode": "1F41F",
@@ -9023,7 +9493,8 @@
       "nature",
       "wildlife"
     ],
-    "moji": "🐟"
+    "moji": "🐟",
+    "emoji_order": 246
   },
   "fish_cake": {
     "unicode": "1F365",
@@ -9044,7 +9515,8 @@
       "naruto",
       "sushi"
     ],
-    "moji": "🍥"
+    "moji": "🍥",
+    "emoji_order": 386
   },
   "fishing_pole_and_fish": {
     "unicode": "1F3A3",
@@ -9063,7 +9535,8 @@
       "vacation",
       "sport"
     ],
-    "moji": "🎣"
+    "moji": "🎣",
+    "emoji_order": 439
   },
   "fist": {
     "unicode": "270A",
@@ -9084,7 +9557,8 @@
       "diversity",
       "condolence"
     ],
-    "moji": "✊"
+    "moji": "✊",
+    "emoji_order": 94
   },
   "fist_tone1": {
     "unicode": "270A-1F3FB",
@@ -9099,7 +9573,8 @@
       "grasp",
       "hand"
     ],
-    "moji": "✊🏻"
+    "moji": "✊🏻",
+    "emoji_order": 1325
   },
   "fist_tone2": {
     "unicode": "270A-1F3FC",
@@ -9114,7 +9589,8 @@
       "grasp",
       "hand"
     ],
-    "moji": "✊🏼"
+    "moji": "✊🏼",
+    "emoji_order": 1326
   },
   "fist_tone3": {
     "unicode": "270A-1F3FD",
@@ -9129,7 +9605,8 @@
       "grasp",
       "hand"
     ],
-    "moji": "✊🏽"
+    "moji": "✊🏽",
+    "emoji_order": 1327
   },
   "fist_tone4": {
     "unicode": "270A-1F3FE",
@@ -9144,7 +9621,8 @@
       "grasp",
       "hand"
     ],
-    "moji": "✊🏾"
+    "moji": "✊🏾",
+    "emoji_order": 1328
   },
   "fist_tone5": {
     "unicode": "270A-1F3FF",
@@ -9159,7 +9637,8 @@
       "grasp",
       "hand"
     ],
-    "moji": "✊🏿"
+    "moji": "✊🏿",
+    "emoji_order": 1329
   },
   "five": {
     "moji": "5️⃣",
@@ -9179,7 +9658,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 907
   },
   "flag_ac": {
     "unicode": "1F1E6-1F1E8",
@@ -9197,7 +9677,8 @@
       "ac",
       "flag"
     ],
-    "moji": "🇦🇨"
+    "moji": "🇦🇨",
+    "emoji_order": 1038
   },
   "flag_ad": {
     "unicode": "1F1E6-1F1E9",
@@ -9215,7 +9696,8 @@
       "ad",
       "flag"
     ],
-    "moji": "🇦🇩"
+    "moji": "🇦🇩",
+    "emoji_order": 1042
   },
   "flag_ae": {
     "unicode": "1F1E6-1F1EA",
@@ -9233,7 +9715,8 @@
       "ae",
       "flag"
     ],
-    "moji": "🇦🇪"
+    "moji": "🇦🇪",
+    "emoji_order": 1241
   },
   "flag_af": {
     "unicode": "1F1E6-1F1EB",
@@ -9252,7 +9735,8 @@
       "af",
       "flag"
     ],
-    "moji": "🇦🇫"
+    "moji": "🇦🇫",
+    "emoji_order": 1039
   },
   "flag_ag": {
     "unicode": "1F1E6-1F1EC",
@@ -9270,7 +9754,8 @@
       "ag",
       "flag"
     ],
-    "moji": "🇦🇬"
+    "moji": "🇦🇬",
+    "emoji_order": 1045
   },
   "flag_ai": {
     "unicode": "1F1E6-1F1EE",
@@ -9288,7 +9773,8 @@
       "ai",
       "flag"
     ],
-    "moji": "🇦🇮"
+    "moji": "🇦🇮",
+    "emoji_order": 1044
   },
   "flag_al": {
     "unicode": "1F1E6-1F1F1",
@@ -9307,7 +9793,8 @@
       "al",
       "flag"
     ],
-    "moji": "🇦🇱"
+    "moji": "🇦🇱",
+    "emoji_order": 1040
   },
   "flag_am": {
     "unicode": "1F1E6-1F1F2",
@@ -9326,7 +9813,8 @@
       "am",
       "flag"
     ],
-    "moji": "🇦🇲"
+    "moji": "🇦🇲",
+    "emoji_order": 1047
   },
   "flag_ao": {
     "unicode": "1F1E6-1F1F4",
@@ -9344,7 +9832,8 @@
       "ao",
       "flag"
     ],
-    "moji": "🇦🇴"
+    "moji": "🇦🇴",
+    "emoji_order": 1043
   },
   "flag_aq": {
     "unicode": "1F1E6-1F1F6",
@@ -9360,7 +9849,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇦🇶"
+    "moji": "🇦🇶",
+    "emoji_order": 1281
   },
   "flag_ar": {
     "unicode": "1F1E6-1F1F7",
@@ -9378,7 +9868,8 @@
       "ar",
       "flag"
     ],
-    "moji": "🇦🇷"
+    "moji": "🇦🇷",
+    "emoji_order": 1046
   },
   "flag_as": {
     "unicode": "1F1E6-1F1F8",
@@ -9394,7 +9885,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇦🇸"
+    "moji": "🇦🇸",
+    "emoji_order": 1280
   },
   "flag_at": {
     "unicode": "1F1E6-1F1F9",
@@ -9414,7 +9906,8 @@
       "at",
       "flag"
     ],
-    "moji": "🇦🇹"
+    "moji": "🇦🇹",
+    "emoji_order": 1050
   },
   "flag_au": {
     "unicode": "1F1E6-1F1FA",
@@ -9432,7 +9925,8 @@
       "au",
       "flag"
     ],
-    "moji": "🇦🇺"
+    "moji": "🇦🇺",
+    "emoji_order": 1049
   },
   "flag_aw": {
     "unicode": "1F1E6-1F1FC",
@@ -9450,7 +9944,8 @@
       "aw",
       "flag"
     ],
-    "moji": "🇦🇼"
+    "moji": "🇦🇼",
+    "emoji_order": 1048
   },
   "flag_ax": {
     "unicode": "1F1E6-1F1FD",
@@ -9466,7 +9961,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇦🇽"
+    "moji": "🇦🇽",
+    "emoji_order": 1257
   },
   "flag_az": {
     "unicode": "1F1E6-1F1FF",
@@ -9485,7 +9981,8 @@
       "az",
       "flag"
     ],
-    "moji": "🇦🇿"
+    "moji": "🇦🇿",
+    "emoji_order": 1051
   },
   "flag_ba": {
     "unicode": "1F1E7-1F1E6",
@@ -9504,7 +10001,8 @@
       "ba",
       "flag"
     ],
-    "moji": "🇧🇦"
+    "moji": "🇧🇦",
+    "emoji_order": 1063
   },
   "flag_bb": {
     "unicode": "1F1E7-1F1E7",
@@ -9522,7 +10020,8 @@
       "bb",
       "flag"
     ],
-    "moji": "🇧🇧"
+    "moji": "🇧🇧",
+    "emoji_order": 1055
   },
   "flag_bd": {
     "unicode": "1F1E7-1F1E9",
@@ -9540,7 +10039,8 @@
       "bd",
       "flag"
     ],
-    "moji": "🇧🇩"
+    "moji": "🇧🇩",
+    "emoji_order": 1054
   },
   "flag_be": {
     "unicode": "1F1E7-1F1EA",
@@ -9560,7 +10060,8 @@
       "be",
       "flag"
     ],
-    "moji": "🇧🇪"
+    "moji": "🇧🇪",
+    "emoji_order": 1057
   },
   "flag_bf": {
     "unicode": "1F1E7-1F1EB",
@@ -9578,7 +10079,8 @@
       "bf",
       "flag"
     ],
-    "moji": "🇧🇫"
+    "moji": "🇧🇫",
+    "emoji_order": 1068
   },
   "flag_bg": {
     "unicode": "1F1E7-1F1EC",
@@ -9596,7 +10098,8 @@
       "bg",
       "flag"
     ],
-    "moji": "🇧🇬"
+    "moji": "🇧🇬",
+    "emoji_order": 1067
   },
   "flag_bh": {
     "unicode": "1F1E7-1F1ED",
@@ -9615,7 +10118,8 @@
       "bh",
       "flag"
     ],
-    "moji": "🇧🇭"
+    "moji": "🇧🇭",
+    "emoji_order": 1053
   },
   "flag_bi": {
     "unicode": "1F1E7-1F1EE",
@@ -9633,7 +10137,8 @@
       "bi",
       "flag"
     ],
-    "moji": "🇧🇮"
+    "moji": "🇧🇮",
+    "emoji_order": 1069
   },
   "flag_bj": {
     "unicode": "1F1E7-1F1EF",
@@ -9651,7 +10156,8 @@
       "bj",
       "flag"
     ],
-    "moji": "🇧🇯"
+    "moji": "🇧🇯",
+    "emoji_order": 1059
   },
   "flag_bl": {
     "unicode": "1F1E7-1F1F1",
@@ -9667,7 +10173,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇧🇱"
+    "moji": "🇧🇱",
+    "emoji_order": 1268
   },
   "flag_black": {
     "unicode": "1F3F4",
@@ -9684,7 +10191,8 @@
       "signal",
       "object"
     ],
-    "moji": "🏴"
+    "moji": "🏴",
+    "emoji_order": 755
   },
   "flag_bm": {
     "unicode": "1F1E7-1F1F2",
@@ -9702,7 +10210,8 @@
       "bm",
       "flag"
     ],
-    "moji": "🇧🇲"
+    "moji": "🇧🇲",
+    "emoji_order": 1060
   },
   "flag_bn": {
     "unicode": "1F1E7-1F1F3",
@@ -9720,7 +10229,8 @@
       "bn",
       "flag"
     ],
-    "moji": "🇧🇳"
+    "moji": "🇧🇳",
+    "emoji_order": 1066
   },
   "flag_bo": {
     "unicode": "1F1E7-1F1F4",
@@ -9738,7 +10248,8 @@
       "bo",
       "flag"
     ],
-    "moji": "🇧🇴"
+    "moji": "🇧🇴",
+    "emoji_order": 1062
   },
   "flag_bq": {
     "unicode": "1F1E7-1F1F6",
@@ -9754,7 +10265,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇧🇶"
+    "moji": "🇧🇶",
+    "emoji_order": 1260
   },
   "flag_br": {
     "unicode": "1F1E7-1F1F7",
@@ -9773,7 +10285,8 @@
       "br",
       "flag"
     ],
-    "moji": "🇧🇷"
+    "moji": "🇧🇷",
+    "emoji_order": 1065
   },
   "flag_bs": {
     "unicode": "1F1E7-1F1F8",
@@ -9791,7 +10304,8 @@
       "bs",
       "flag"
     ],
-    "moji": "🇧🇸"
+    "moji": "🇧🇸",
+    "emoji_order": 1052
   },
   "flag_bt": {
     "unicode": "1F1E7-1F1F9",
@@ -9809,7 +10323,8 @@
       "bt",
       "flag"
     ],
-    "moji": "🇧🇹"
+    "moji": "🇧🇹",
+    "emoji_order": 1061
   },
   "flag_bv": {
     "unicode": "1F1E7-1F1FB",
@@ -9825,7 +10340,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇧🇻"
+    "moji": "🇧🇻",
+    "emoji_order": 1272
   },
   "flag_bw": {
     "unicode": "1F1E7-1F1FC",
@@ -9843,7 +10359,8 @@
       "bw",
       "flag"
     ],
-    "moji": "🇧🇼"
+    "moji": "🇧🇼",
+    "emoji_order": 1064
   },
   "flag_by": {
     "unicode": "1F1E7-1F1FE",
@@ -9862,7 +10379,8 @@
       "by",
       "flag"
     ],
-    "moji": "🇧🇾"
+    "moji": "🇧🇾",
+    "emoji_order": 1056
   },
   "flag_bz": {
     "unicode": "1F1E7-1F1FF",
@@ -9880,7 +10398,8 @@
       "bz",
       "flag"
     ],
-    "moji": "🇧🇿"
+    "moji": "🇧🇿",
+    "emoji_order": 1058
   },
   "flag_ca": {
     "unicode": "1F1E8-1F1E6",
@@ -9898,7 +10417,8 @@
       "ca",
       "flag"
     ],
-    "moji": "🇨🇦"
+    "moji": "🇨🇦",
+    "emoji_order": 1073
   },
   "flag_cc": {
     "unicode": "1F1E8-1F1E8",
@@ -9914,7 +10434,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇨🇨"
+    "moji": "🇨🇨",
+    "emoji_order": 1262
   },
   "flag_cd": {
     "unicode": "1F1E8-1F1E9",
@@ -9934,7 +10455,8 @@
       "cd",
       "flag"
     ],
-    "moji": "🇨🇩"
+    "moji": "🇨🇩",
+    "emoji_order": 1082
   },
   "flag_cf": {
     "unicode": "1F1E8-1F1EB",
@@ -9952,7 +10474,8 @@
       "cf",
       "flag"
     ],
-    "moji": "🇨🇫"
+    "moji": "🇨🇫",
+    "emoji_order": 1075
   },
   "flag_cg": {
     "unicode": "1F1E8-1F1EC",
@@ -9970,7 +10493,8 @@
       "cg",
       "flag"
     ],
-    "moji": "🇨🇬"
+    "moji": "🇨🇬",
+    "emoji_order": 1081
   },
   "flag_ch": {
     "unicode": "1F1E8-1F1ED",
@@ -9989,7 +10513,8 @@
       "neutral",
       "flag"
     ],
-    "moji": "🇨🇭"
+    "moji": "🇨🇭",
+    "emoji_order": 1225
   },
   "flag_ci": {
     "unicode": "1F1E8-1F1EE",
@@ -10007,7 +10532,8 @@
       "ci",
       "flag"
     ],
-    "moji": "🇨🇮"
+    "moji": "🇨🇮",
+    "emoji_order": 1131
   },
   "flag_ck": {
     "unicode": "1F1E8-1F1F0",
@@ -10023,7 +10549,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇨🇰"
+    "moji": "🇨🇰",
+    "emoji_order": 1283
   },
   "flag_cl": {
     "unicode": "1F1E8-1F1F1",
@@ -10041,7 +10568,8 @@
       "cl",
       "flag"
     ],
-    "moji": "🇨🇱"
+    "moji": "🇨🇱",
+    "emoji_order": 1077
   },
   "flag_cm": {
     "unicode": "1F1E8-1F1F2",
@@ -10059,7 +10587,8 @@
       "cm",
       "flag"
     ],
-    "moji": "🇨🇲"
+    "moji": "🇨🇲",
+    "emoji_order": 1072
   },
   "flag_cn": {
     "unicode": "1F1E8-1F1F3",
@@ -10080,7 +10609,8 @@
       "cn",
       "flag"
     ],
-    "moji": "🇨🇳"
+    "moji": "🇨🇳",
+    "emoji_order": 1078
   },
   "flag_co": {
     "unicode": "1F1E8-1F1F4",
@@ -10098,7 +10628,8 @@
       "co",
       "flag"
     ],
-    "moji": "🇨🇴"
+    "moji": "🇨🇴",
+    "emoji_order": 1079
   },
   "flag_cp": {
     "unicode": "1F1E8-1F1F5",
@@ -10114,7 +10645,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇨🇵"
+    "moji": "🇨🇵",
+    "emoji_order": 1278
   },
   "flag_cr": {
     "unicode": "1F1E8-1F1F7",
@@ -10132,7 +10664,8 @@
       "cr",
       "flag"
     ],
-    "moji": "🇨🇷"
+    "moji": "🇨🇷",
+    "emoji_order": 1083
   },
   "flag_cu": {
     "unicode": "1F1E8-1F1FA",
@@ -10150,7 +10683,8 @@
       "cu",
       "flag"
     ],
-    "moji": "🇨🇺"
+    "moji": "🇨🇺",
+    "emoji_order": 1085
   },
   "flag_cv": {
     "unicode": "1F1E8-1F1FB",
@@ -10169,7 +10703,8 @@
       "cv",
       "flag"
     ],
-    "moji": "🇨🇻"
+    "moji": "🇨🇻",
+    "emoji_order": 1070
   },
   "flag_cw": {
     "unicode": "1F1E8-1F1FC",
@@ -10185,7 +10720,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇨🇼"
+    "moji": "🇨🇼",
+    "emoji_order": 1284
   },
   "flag_cx": {
     "unicode": "1F1E8-1F1FD",
@@ -10201,7 +10737,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇨🇽"
+    "moji": "🇨🇽",
+    "emoji_order": 1261
   },
   "flag_cy": {
     "unicode": "1F1E8-1F1FE",
@@ -10221,7 +10758,8 @@
       "cy",
       "flag"
     ],
-    "moji": "🇨🇾"
+    "moji": "🇨🇾",
+    "emoji_order": 1086
   },
   "flag_cz": {
     "unicode": "1F1E8-1F1FF",
@@ -10240,7 +10778,8 @@
       "cz",
       "flag"
     ],
-    "moji": "🇨🇿"
+    "moji": "🇨🇿",
+    "emoji_order": 1087
   },
   "flag_de": {
     "unicode": "1F1E9-1F1EA",
@@ -10260,7 +10799,8 @@
       "de",
       "flag"
     ],
-    "moji": "🇩🇪"
+    "moji": "🇩🇪",
+    "emoji_order": 1108
   },
   "flag_dg": {
     "unicode": "1F1E9-1F1EC",
@@ -10276,7 +10816,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇩🇬"
+    "moji": "🇩🇬",
+    "emoji_order": 1279
   },
   "flag_dj": {
     "unicode": "1F1E9-1F1EF",
@@ -10294,7 +10835,8 @@
       "dj",
       "flag"
     ],
-    "moji": "🇩🇯"
+    "moji": "🇩🇯",
+    "emoji_order": 1089
   },
   "flag_dk": {
     "unicode": "1F1E9-1F1F0",
@@ -10313,7 +10855,8 @@
       "dk",
       "flag"
     ],
-    "moji": "🇩🇰"
+    "moji": "🇩🇰",
+    "emoji_order": 1088
   },
   "flag_dm": {
     "unicode": "1F1E9-1F1F2",
@@ -10331,7 +10874,8 @@
       "dm",
       "flag"
     ],
-    "moji": "🇩🇲"
+    "moji": "🇩🇲",
+    "emoji_order": 1090
   },
   "flag_do": {
     "unicode": "1F1E9-1F1F4",
@@ -10349,7 +10893,8 @@
       "do",
       "flag"
     ],
-    "moji": "🇩🇴"
+    "moji": "🇩🇴",
+    "emoji_order": 1091
   },
   "flag_dz": {
     "unicode": "1F1E9-1F1FF",
@@ -10369,7 +10914,8 @@
       "dz",
       "flag"
     ],
-    "moji": "🇩🇿"
+    "moji": "🇩🇿",
+    "emoji_order": 1041
   },
   "flag_ea": {
     "unicode": "1F1EA-1F1E6",
@@ -10385,7 +10931,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇪🇦"
+    "moji": "🇪🇦",
+    "emoji_order": 1277
   },
   "flag_ec": {
     "unicode": "1F1EA-1F1E8",
@@ -10403,7 +10950,8 @@
       "ec",
       "flag"
     ],
-    "moji": "🇪🇨"
+    "moji": "🇪🇨",
+    "emoji_order": 1092
   },
   "flag_ee": {
     "unicode": "1F1EA-1F1EA",
@@ -10422,7 +10970,8 @@
       "ee",
       "flag"
     ],
-    "moji": "🇪🇪"
+    "moji": "🇪🇪",
+    "emoji_order": 1097
   },
   "flag_eg": {
     "unicode": "1F1EA-1F1EC",
@@ -10441,7 +10990,8 @@
       "eg",
       "flag"
     ],
-    "moji": "🇪🇬"
+    "moji": "🇪🇬",
+    "emoji_order": 1093
   },
   "flag_eh": {
     "unicode": "1F1EA-1F1ED",
@@ -10462,7 +11012,8 @@
       "eh",
       "flag"
     ],
-    "moji": "🇪🇭"
+    "moji": "🇪🇭",
+    "emoji_order": 1252
   },
   "flag_er": {
     "unicode": "1F1EA-1F1F7",
@@ -10481,7 +11032,8 @@
       "er",
       "flag"
     ],
-    "moji": "🇪🇷"
+    "moji": "🇪🇷",
+    "emoji_order": 1096
   },
   "flag_es": {
     "unicode": "1F1EA-1F1F8",
@@ -10501,7 +11053,8 @@
       "es",
       "flag"
     ],
-    "moji": "🇪🇸"
+    "moji": "🇪🇸",
+    "emoji_order": 1219
   },
   "flag_et": {
     "unicode": "1F1EA-1F1F9",
@@ -10521,7 +11074,8 @@
       "et",
       "flag"
     ],
-    "moji": "🇪🇹"
+    "moji": "🇪🇹",
+    "emoji_order": 1098
   },
   "flag_eu": {
     "unicode": "1F1EA-1F1FA",
@@ -10537,7 +11091,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇪🇺"
+    "moji": "🇪🇺",
+    "emoji_order": 1285
   },
   "flag_fi": {
     "unicode": "1F1EB-1F1EE",
@@ -10556,7 +11111,8 @@
       "fi",
       "flag"
     ],
-    "moji": "🇫🇮"
+    "moji": "🇫🇮",
+    "emoji_order": 1102
   },
   "flag_fj": {
     "unicode": "1F1EB-1F1EF",
@@ -10574,7 +11130,8 @@
       "fj",
       "flag"
     ],
-    "moji": "🇫🇯"
+    "moji": "🇫🇯",
+    "emoji_order": 1101
   },
   "flag_fk": {
     "unicode": "1F1EB-1F1F0",
@@ -10593,7 +11150,8 @@
       "fk",
       "flag"
     ],
-    "moji": "🇫🇰"
+    "moji": "🇫🇰",
+    "emoji_order": 1099
   },
   "flag_fm": {
     "unicode": "1F1EB-1F1F2",
@@ -10611,7 +11169,8 @@
       "fm",
       "flag"
     ],
-    "moji": "🇫🇲"
+    "moji": "🇫🇲",
+    "emoji_order": 1163
   },
   "flag_fo": {
     "unicode": "1F1EB-1F1F4",
@@ -10630,7 +11189,8 @@
       "fo",
       "flag"
     ],
-    "moji": "🇫🇴"
+    "moji": "🇫🇴",
+    "emoji_order": 1100
   },
   "flag_fr": {
     "unicode": "1F1EB-1F1F7",
@@ -10649,7 +11209,8 @@
       "fr",
       "flag"
     ],
-    "moji": "🇫🇷"
+    "moji": "🇫🇷",
+    "emoji_order": 1103
   },
   "flag_ga": {
     "unicode": "1F1EC-1F1E6",
@@ -10667,7 +11228,8 @@
       "ga",
       "flag"
     ],
-    "moji": "🇬🇦"
+    "moji": "🇬🇦",
+    "emoji_order": 1105
   },
   "flag_gb": {
     "unicode": "1F1EC-1F1E7",
@@ -10689,7 +11251,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇬🇧"
+    "moji": "🇬🇧",
+    "emoji_order": 1242
   },
   "flag_gd": {
     "unicode": "1F1EC-1F1E9",
@@ -10707,7 +11270,8 @@
       "gd",
       "flag"
     ],
-    "moji": "🇬🇩"
+    "moji": "🇬🇩",
+    "emoji_order": 1113
   },
   "flag_ge": {
     "unicode": "1F1EC-1F1EA",
@@ -10727,7 +11291,8 @@
       "ge",
       "flag"
     ],
-    "moji": "🇬🇪"
+    "moji": "🇬🇪",
+    "emoji_order": 1107
   },
   "flag_gf": {
     "unicode": "1F1EC-1F1EB",
@@ -10743,7 +11308,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇬🇫"
+    "moji": "🇬🇫",
+    "emoji_order": 1286
   },
   "flag_gg": {
     "unicode": "1F1EC-1F1EC",
@@ -10759,7 +11325,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇬🇬"
+    "moji": "🇬🇬",
+    "emoji_order": 1263
   },
   "flag_gh": {
     "unicode": "1F1EC-1F1ED",
@@ -10777,7 +11344,8 @@
       "gh",
       "flag"
     ],
-    "moji": "🇬🇭"
+    "moji": "🇬🇭",
+    "emoji_order": 1109
   },
   "flag_gi": {
     "unicode": "1F1EC-1F1EE",
@@ -10795,7 +11363,8 @@
       "gi",
       "flag"
     ],
-    "moji": "🇬🇮"
+    "moji": "🇬🇮",
+    "emoji_order": 1110
   },
   "flag_gl": {
     "unicode": "1F1EC-1F1F1",
@@ -10814,7 +11383,8 @@
       "gl",
       "flag"
     ],
-    "moji": "🇬🇱"
+    "moji": "🇬🇱",
+    "emoji_order": 1112
   },
   "flag_gm": {
     "unicode": "1F1EC-1F1F2",
@@ -10832,7 +11402,8 @@
       "gm",
       "flag"
     ],
-    "moji": "🇬🇲"
+    "moji": "🇬🇲",
+    "emoji_order": 1106
   },
   "flag_gn": {
     "unicode": "1F1EC-1F1F3",
@@ -10851,7 +11422,8 @@
       "gn",
       "flag"
     ],
-    "moji": "🇬🇳"
+    "moji": "🇬🇳",
+    "emoji_order": 1116
   },
   "flag_gp": {
     "unicode": "1F1EC-1F1F5",
@@ -10867,7 +11439,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇬🇵"
+    "moji": "🇬🇵",
+    "emoji_order": 1288
   },
   "flag_gq": {
     "unicode": "1F1EC-1F1F6",
@@ -10886,7 +11459,8 @@
       "gq",
       "flag"
     ],
-    "moji": "🇬🇶"
+    "moji": "🇬🇶",
+    "emoji_order": 1095
   },
   "flag_gr": {
     "unicode": "1F1EC-1F1F7",
@@ -10906,7 +11480,8 @@
       "gr",
       "flag"
     ],
-    "moji": "🇬🇷"
+    "moji": "🇬🇷",
+    "emoji_order": 1111
   },
   "flag_gs": {
     "unicode": "1F1EC-1F1F8",
@@ -10922,7 +11497,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇬🇸"
+    "moji": "🇬🇸",
+    "emoji_order": 1270
   },
   "flag_gt": {
     "unicode": "1F1EC-1F1F9",
@@ -10940,7 +11516,8 @@
       "gt",
       "flag"
     ],
-    "moji": "🇬🇹"
+    "moji": "🇬🇹",
+    "emoji_order": 1115
   },
   "flag_gu": {
     "unicode": "1F1EC-1F1FA",
@@ -10958,7 +11535,8 @@
       "gu",
       "flag"
     ],
-    "moji": "🇬🇺"
+    "moji": "🇬🇺",
+    "emoji_order": 1114
   },
   "flag_gw": {
     "unicode": "1F1EC-1F1FC",
@@ -10978,7 +11556,8 @@
       "gw",
       "flag"
     ],
-    "moji": "🇬🇼"
+    "moji": "🇬🇼",
+    "emoji_order": 1117
   },
   "flag_gy": {
     "unicode": "1F1EC-1F1FE",
@@ -10996,7 +11575,8 @@
       "gy",
       "flag"
     ],
-    "moji": "🇬🇾"
+    "moji": "🇬🇾",
+    "emoji_order": 1118
   },
   "flag_hk": {
     "unicode": "1F1ED-1F1F0",
@@ -11015,7 +11595,8 @@
       "hk",
       "flag"
     ],
-    "moji": "🇭🇰"
+    "moji": "🇭🇰",
+    "emoji_order": 1121
   },
   "flag_hm": {
     "unicode": "1F1ED-1F1F2",
@@ -11031,7 +11612,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇭🇲"
+    "moji": "🇭🇲",
+    "emoji_order": 1273
   },
   "flag_hn": {
     "unicode": "1F1ED-1F1F3",
@@ -11049,7 +11631,8 @@
       "hn",
       "flag"
     ],
-    "moji": "🇭🇳"
+    "moji": "🇭🇳",
+    "emoji_order": 1120
   },
   "flag_hr": {
     "unicode": "1F1ED-1F1F7",
@@ -11068,7 +11651,8 @@
       "hr",
       "flag"
     ],
-    "moji": "🇭🇷"
+    "moji": "🇭🇷",
+    "emoji_order": 1084
   },
   "flag_ht": {
     "unicode": "1F1ED-1F1F9",
@@ -11086,7 +11670,8 @@
       "ht",
       "flag"
     ],
-    "moji": "🇭🇹"
+    "moji": "🇭🇹",
+    "emoji_order": 1119
   },
   "flag_hu": {
     "unicode": "1F1ED-1F1FA",
@@ -11105,7 +11690,8 @@
       "hu",
       "flag"
     ],
-    "moji": "🇭🇺"
+    "moji": "🇭🇺",
+    "emoji_order": 1122
   },
   "flag_ic": {
     "unicode": "1F1EE-1F1E8",
@@ -11121,7 +11707,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇮🇨"
+    "moji": "🇮🇨",
+    "emoji_order": 1276
   },
   "flag_id": {
     "unicode": "1F1EE-1F1E9",
@@ -11139,7 +11726,8 @@
       "id",
       "flag"
     ],
-    "moji": "🇮🇩"
+    "moji": "🇮🇩",
+    "emoji_order": 1125
   },
   "flag_ie": {
     "unicode": "1F1EE-1F1EA",
@@ -11159,7 +11747,8 @@
       "ie",
       "flag"
     ],
-    "moji": "🇮🇪"
+    "moji": "🇮🇪",
+    "emoji_order": 1128
   },
   "flag_il": {
     "unicode": "1F1EE-1F1F1",
@@ -11180,7 +11769,8 @@
       "jew",
       "flag"
     ],
-    "moji": "🇮🇱"
+    "moji": "🇮🇱",
+    "emoji_order": 1129
   },
   "flag_im": {
     "unicode": "1F1EE-1F1F2",
@@ -11196,7 +11786,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇮🇲"
+    "moji": "🇮🇲",
+    "emoji_order": 1264
   },
   "flag_in": {
     "unicode": "1F1EE-1F1F3",
@@ -11215,7 +11806,8 @@
       "in",
       "flag"
     ],
-    "moji": "🇮🇳"
+    "moji": "🇮🇳",
+    "emoji_order": 1124
   },
   "flag_io": {
     "unicode": "1F1EE-1F1F4",
@@ -11231,7 +11823,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇮🇴"
+    "moji": "🇮🇴",
+    "emoji_order": 1259
   },
   "flag_iq": {
     "unicode": "1F1EE-1F1F6",
@@ -11249,7 +11842,8 @@
       "iq",
       "flag"
     ],
-    "moji": "🇮🇶"
+    "moji": "🇮🇶",
+    "emoji_order": 1127
   },
   "flag_ir": {
     "unicode": "1F1EE-1F1F7",
@@ -11267,7 +11861,8 @@
       "ir",
       "flag"
     ],
-    "moji": "🇮🇷"
+    "moji": "🇮🇷",
+    "emoji_order": 1126
   },
   "flag_is": {
     "unicode": "1F1EE-1F1F8",
@@ -11286,7 +11881,8 @@
       "is",
       "flag"
     ],
-    "moji": "🇮🇸"
+    "moji": "🇮🇸",
+    "emoji_order": 1123
   },
   "flag_it": {
     "unicode": "1F1EE-1F1F9",
@@ -11306,7 +11902,8 @@
       "italian",
       "flag"
     ],
-    "moji": "🇮🇹"
+    "moji": "🇮🇹",
+    "emoji_order": 1130
   },
   "flag_je": {
     "unicode": "1F1EF-1F1EA",
@@ -11324,7 +11921,8 @@
       "je",
       "flag"
     ],
-    "moji": "🇯🇪"
+    "moji": "🇯🇪",
+    "emoji_order": 1134
   },
   "flag_jm": {
     "unicode": "1F1EF-1F1F2",
@@ -11342,7 +11940,8 @@
       "jm",
       "flag"
     ],
-    "moji": "🇯🇲"
+    "moji": "🇯🇲",
+    "emoji_order": 1132
   },
   "flag_jo": {
     "unicode": "1F1EF-1F1F4",
@@ -11361,7 +11960,8 @@
       "jo",
       "flag"
     ],
-    "moji": "🇯🇴"
+    "moji": "🇯🇴",
+    "emoji_order": 1135
   },
   "flag_jp": {
     "unicode": "1F1EF-1F1F5",
@@ -11381,7 +11981,8 @@
       "japan",
       "flag"
     ],
-    "moji": "🇯🇵"
+    "moji": "🇯🇵",
+    "emoji_order": 1133
   },
   "flag_ke": {
     "unicode": "1F1F0-1F1EA",
@@ -11399,7 +12000,8 @@
       "ke",
       "flag"
     ],
-    "moji": "🇰🇪"
+    "moji": "🇰🇪",
+    "emoji_order": 1137
   },
   "flag_kg": {
     "unicode": "1F1F0-1F1EC",
@@ -11418,7 +12020,8 @@
       "kg",
       "flag"
     ],
-    "moji": "🇰🇬"
+    "moji": "🇰🇬",
+    "emoji_order": 1141
   },
   "flag_kh": {
     "unicode": "1F1F0-1F1ED",
@@ -11437,7 +12040,8 @@
       "kh",
       "flag"
     ],
-    "moji": "🇰🇭"
+    "moji": "🇰🇭",
+    "emoji_order": 1071
   },
   "flag_ki": {
     "unicode": "1F1F0-1F1EE",
@@ -11457,7 +12061,8 @@
       "ki",
       "flag"
     ],
-    "moji": "🇰🇮"
+    "moji": "🇰🇮",
+    "emoji_order": 1138
   },
   "flag_km": {
     "unicode": "1F1F0-1F1F2",
@@ -11475,7 +12080,8 @@
       "km",
       "flag"
     ],
-    "moji": "🇰🇲"
+    "moji": "🇰🇲",
+    "emoji_order": 1080
   },
   "flag_kn": {
     "unicode": "1F1F0-1F1F3",
@@ -11493,7 +12099,8 @@
       "kn",
       "flag"
     ],
-    "moji": "🇰🇳"
+    "moji": "🇰🇳",
+    "emoji_order": 1201
   },
   "flag_kp": {
     "unicode": "1F1F0-1F1F5",
@@ -11511,7 +12118,8 @@
       "kp",
       "flag"
     ],
-    "moji": "🇰🇵"
+    "moji": "🇰🇵",
+    "emoji_order": 1182
   },
   "flag_kr": {
     "unicode": "1F1F0-1F1F7",
@@ -11530,7 +12138,8 @@
       "kr",
       "flag"
     ],
-    "moji": "🇰🇷"
+    "moji": "🇰🇷",
+    "emoji_order": 1218
   },
   "flag_kw": {
     "unicode": "1F1F0-1F1FC",
@@ -11549,7 +12158,8 @@
       "kw",
       "flag"
     ],
-    "moji": "🇰🇼"
+    "moji": "🇰🇼",
+    "emoji_order": 1140
   },
   "flag_ky": {
     "unicode": "1F1F0-1F1FE",
@@ -11567,7 +12177,8 @@
       "ky",
       "flag"
     ],
-    "moji": "🇰🇾"
+    "moji": "🇰🇾",
+    "emoji_order": 1074
   },
   "flag_kz": {
     "unicode": "1F1F0-1F1FF",
@@ -11586,7 +12197,8 @@
       "kz",
       "flag"
     ],
-    "moji": "🇰🇿"
+    "moji": "🇰🇿",
+    "emoji_order": 1136
   },
   "flag_la": {
     "unicode": "1F1F1-1F1E6",
@@ -11604,7 +12216,8 @@
       "la",
       "flag"
     ],
-    "moji": "🇱🇦"
+    "moji": "🇱🇦",
+    "emoji_order": 1142
   },
   "flag_lb": {
     "unicode": "1F1F1-1F1E7",
@@ -11623,7 +12236,8 @@
       "lb",
       "flag"
     ],
-    "moji": "🇱🇧"
+    "moji": "🇱🇧",
+    "emoji_order": 1144
   },
   "flag_lc": {
     "unicode": "1F1F1-1F1E8",
@@ -11641,7 +12255,8 @@
       "lc",
       "flag"
     ],
-    "moji": "🇱🇨"
+    "moji": "🇱🇨",
+    "emoji_order": 1202
   },
   "flag_li": {
     "unicode": "1F1F1-1F1EE",
@@ -11659,7 +12274,8 @@
       "li",
       "flag"
     ],
-    "moji": "🇱🇮"
+    "moji": "🇱🇮",
+    "emoji_order": 1148
   },
   "flag_lk": {
     "unicode": "1F1F1-1F1F0",
@@ -11677,7 +12293,8 @@
       "lk",
       "flag"
     ],
-    "moji": "🇱🇰"
+    "moji": "🇱🇰",
+    "emoji_order": 1220
   },
   "flag_lr": {
     "unicode": "1F1F1-1F1F7",
@@ -11695,7 +12312,8 @@
       "lr",
       "flag"
     ],
-    "moji": "🇱🇷"
+    "moji": "🇱🇷",
+    "emoji_order": 1146
   },
   "flag_ls": {
     "unicode": "1F1F1-1F1F8",
@@ -11713,7 +12331,8 @@
       "ls",
       "flag"
     ],
-    "moji": "🇱🇸"
+    "moji": "🇱🇸",
+    "emoji_order": 1145
   },
   "flag_lt": {
     "unicode": "1F1F1-1F1F9",
@@ -11732,7 +12351,8 @@
       "lt",
       "flag"
     ],
-    "moji": "🇱🇹"
+    "moji": "🇱🇹",
+    "emoji_order": 1149
   },
   "flag_lu": {
     "unicode": "1F1F1-1F1FA",
@@ -11752,7 +12372,8 @@
       "lu",
       "flag"
     ],
-    "moji": "🇱🇺"
+    "moji": "🇱🇺",
+    "emoji_order": 1150
   },
   "flag_lv": {
     "unicode": "1F1F1-1F1FB",
@@ -11771,7 +12392,8 @@
       "lv",
       "flag"
     ],
-    "moji": "🇱🇻"
+    "moji": "🇱🇻",
+    "emoji_order": 1143
   },
   "flag_ly": {
     "unicode": "1F1F1-1F1FE",
@@ -11790,7 +12412,8 @@
       "ly",
       "flag"
     ],
-    "moji": "🇱🇾"
+    "moji": "🇱🇾",
+    "emoji_order": 1147
   },
   "flag_ma": {
     "unicode": "1F1F2-1F1E6",
@@ -11809,7 +12432,8 @@
       "ma",
       "flag"
     ],
-    "moji": "🇲🇦"
+    "moji": "🇲🇦",
+    "emoji_order": 1169
   },
   "flag_mc": {
     "unicode": "1F1F2-1F1E8",
@@ -11827,7 +12451,8 @@
       "mc",
       "flag"
     ],
-    "moji": "🇲🇨"
+    "moji": "🇲🇨",
+    "emoji_order": 1165
   },
   "flag_md": {
     "unicode": "1F1F2-1F1E9",
@@ -11845,7 +12470,8 @@
       "md",
       "flag"
     ],
-    "moji": "🇲🇩"
+    "moji": "🇲🇩",
+    "emoji_order": 1164
   },
   "flag_me": {
     "unicode": "1F1F2-1F1EA",
@@ -11864,7 +12490,8 @@
       "me",
       "flag"
     ],
-    "moji": "🇲🇪"
+    "moji": "🇲🇪",
+    "emoji_order": 1167
   },
   "flag_mf": {
     "unicode": "1F1F2-1F1EB",
@@ -11880,7 +12507,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇲🇫"
+    "moji": "🇲🇫",
+    "emoji_order": 1294
   },
   "flag_mg": {
     "unicode": "1F1F2-1F1EC",
@@ -11898,7 +12526,8 @@
       "mg",
       "flag"
     ],
-    "moji": "🇲🇬"
+    "moji": "🇲🇬",
+    "emoji_order": 1153
   },
   "flag_mh": {
     "unicode": "1F1F2-1F1ED",
@@ -11916,7 +12545,8 @@
       "mh",
       "flag"
     ],
-    "moji": "🇲🇭"
+    "moji": "🇲🇭",
+    "emoji_order": 1159
   },
   "flag_mk": {
     "unicode": "1F1F2-1F1F0",
@@ -11934,7 +12564,8 @@
       "mk",
       "flag"
     ],
-    "moji": "🇲🇰"
+    "moji": "🇲🇰",
+    "emoji_order": 1152
   },
   "flag_ml": {
     "unicode": "1F1F2-1F1F1",
@@ -11952,7 +12583,8 @@
       "ml",
       "flag"
     ],
-    "moji": "🇲🇱"
+    "moji": "🇲🇱",
+    "emoji_order": 1157
   },
   "flag_mm": {
     "unicode": "1F1F2-1F1F2",
@@ -11971,7 +12603,8 @@
       "mm",
       "flag"
     ],
-    "moji": "🇲🇲"
+    "moji": "🇲🇲",
+    "emoji_order": 1171
   },
   "flag_mn": {
     "unicode": "1F1F2-1F1F3",
@@ -11990,7 +12623,8 @@
       "mn",
       "flag"
     ],
-    "moji": "🇲🇳"
+    "moji": "🇲🇳",
+    "emoji_order": 1166
   },
   "flag_mo": {
     "unicode": "1F1F2-1F1F4",
@@ -12009,7 +12643,8 @@
       "mo",
       "flag"
     ],
-    "moji": "🇲🇴"
+    "moji": "🇲🇴",
+    "emoji_order": 1151
   },
   "flag_mp": {
     "unicode": "1F1F2-1F1F5",
@@ -12025,7 +12660,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇲🇵"
+    "moji": "🇲🇵",
+    "emoji_order": 1290
   },
   "flag_mq": {
     "unicode": "1F1F2-1F1F6",
@@ -12041,7 +12677,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇲🇶"
+    "moji": "🇲🇶",
+    "emoji_order": 1289
   },
   "flag_mr": {
     "unicode": "1F1F2-1F1F7",
@@ -12060,7 +12697,8 @@
       "mr",
       "flag"
     ],
-    "moji": "🇲🇷"
+    "moji": "🇲🇷",
+    "emoji_order": 1160
   },
   "flag_ms": {
     "unicode": "1F1F2-1F1F8",
@@ -12078,7 +12716,8 @@
       "ms",
       "flag"
     ],
-    "moji": "🇲🇸"
+    "moji": "🇲🇸",
+    "emoji_order": 1168
   },
   "flag_mt": {
     "unicode": "1F1F2-1F1F9",
@@ -12096,7 +12735,8 @@
       "mt",
       "flag"
     ],
-    "moji": "🇲🇹"
+    "moji": "🇲🇹",
+    "emoji_order": 1158
   },
   "flag_mu": {
     "unicode": "1F1F2-1F1FA",
@@ -12114,7 +12754,8 @@
       "mu",
       "flag"
     ],
-    "moji": "🇲🇺"
+    "moji": "🇲🇺",
+    "emoji_order": 1161
   },
   "flag_mv": {
     "unicode": "1F1F2-1F1FB",
@@ -12133,7 +12774,8 @@
       "mv",
       "flag"
     ],
-    "moji": "🇲🇻"
+    "moji": "🇲🇻",
+    "emoji_order": 1156
   },
   "flag_mw": {
     "unicode": "1F1F2-1F1FC",
@@ -12151,7 +12793,8 @@
       "mw",
       "flag"
     ],
-    "moji": "🇲🇼"
+    "moji": "🇲🇼",
+    "emoji_order": 1154
   },
   "flag_mx": {
     "unicode": "1F1F2-1F1FD",
@@ -12170,7 +12813,8 @@
       "mexican",
       "flag"
     ],
-    "moji": "🇲🇽"
+    "moji": "🇲🇽",
+    "emoji_order": 1162
   },
   "flag_my": {
     "unicode": "1F1F2-1F1FE",
@@ -12188,7 +12832,8 @@
       "my",
       "flag"
     ],
-    "moji": "🇲🇾"
+    "moji": "🇲🇾",
+    "emoji_order": 1155
   },
   "flag_mz": {
     "unicode": "1F1F2-1F1FF",
@@ -12207,7 +12852,8 @@
       "mz",
       "flag"
     ],
-    "moji": "🇲🇿"
+    "moji": "🇲🇿",
+    "emoji_order": 1170
   },
   "flag_na": {
     "unicode": "1F1F3-1F1E6",
@@ -12225,7 +12871,8 @@
       "na",
       "flag"
     ],
-    "moji": "🇳🇦"
+    "moji": "🇳🇦",
+    "emoji_order": 1172
   },
   "flag_nc": {
     "unicode": "1F1F3-1F1E8",
@@ -12246,7 +12893,8 @@
       "nc",
       "flag"
     ],
-    "moji": "🇳🇨"
+    "moji": "🇳🇨",
+    "emoji_order": 1176
   },
   "flag_ne": {
     "unicode": "1F1F3-1F1EA",
@@ -12264,7 +12912,8 @@
       "ne",
       "flag"
     ],
-    "moji": "🇳🇪"
+    "moji": "🇳🇪",
+    "emoji_order": 1179
   },
   "flag_nf": {
     "unicode": "1F1F3-1F1EB",
@@ -12280,7 +12929,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇳🇫"
+    "moji": "🇳🇫",
+    "emoji_order": 1266
   },
   "flag_ng": {
     "unicode": "1F1F3-1F1EC",
@@ -12298,7 +12948,8 @@
       "ng",
       "flag"
     ],
-    "moji": "🇳🇬"
+    "moji": "🇳🇬",
+    "emoji_order": 1180
   },
   "flag_ni": {
     "unicode": "1F1F3-1F1EE",
@@ -12316,7 +12967,8 @@
       "ni",
       "flag"
     ],
-    "moji": "🇳🇮"
+    "moji": "🇳🇮",
+    "emoji_order": 1178
   },
   "flag_nl": {
     "unicode": "1F1F3-1F1F1",
@@ -12336,7 +12988,8 @@
       "nl",
       "flag"
     ],
-    "moji": "🇳🇱"
+    "moji": "🇳🇱",
+    "emoji_order": 1175
   },
   "flag_no": {
     "unicode": "1F1F3-1F1F4",
@@ -12355,7 +13008,8 @@
       "no",
       "flag"
     ],
-    "moji": "🇳🇴"
+    "moji": "🇳🇴",
+    "emoji_order": 1183
   },
   "flag_np": {
     "unicode": "1F1F3-1F1F5",
@@ -12373,7 +13027,8 @@
       "np",
       "flag"
     ],
-    "moji": "🇳🇵"
+    "moji": "🇳🇵",
+    "emoji_order": 1174
   },
   "flag_nr": {
     "unicode": "1F1F3-1F1F7",
@@ -12391,7 +13046,8 @@
       "nr",
       "flag"
     ],
-    "moji": "🇳🇷"
+    "moji": "🇳🇷",
+    "emoji_order": 1173
   },
   "flag_nu": {
     "unicode": "1F1F3-1F1FA",
@@ -12409,7 +13065,8 @@
       "nu",
       "flag"
     ],
-    "moji": "🇳🇺"
+    "moji": "🇳🇺",
+    "emoji_order": 1181
   },
   "flag_nz": {
     "unicode": "1F1F3-1F1FF",
@@ -12428,7 +13085,8 @@
       "nz",
       "flag"
     ],
-    "moji": "🇳🇿"
+    "moji": "🇳🇿",
+    "emoji_order": 1177
   },
   "flag_om": {
     "unicode": "1F1F4-1F1F2",
@@ -12447,7 +13105,8 @@
       "om",
       "flag"
     ],
-    "moji": "🇴🇲"
+    "moji": "🇴🇲",
+    "emoji_order": 1184
   },
   "flag_pa": {
     "unicode": "1F1F5-1F1E6",
@@ -12465,7 +13124,8 @@
       "pa",
       "flag"
     ],
-    "moji": "🇵🇦"
+    "moji": "🇵🇦",
+    "emoji_order": 1188
   },
   "flag_pe": {
     "unicode": "1F1F5-1F1EA",
@@ -12483,7 +13143,8 @@
       "pe",
       "flag"
     ],
-    "moji": "🇵🇪"
+    "moji": "🇵🇪",
+    "emoji_order": 1191
   },
   "flag_pf": {
     "unicode": "1F1F5-1F1EB",
@@ -12503,7 +13164,8 @@
       "pf",
       "flag"
     ],
-    "moji": "🇵🇫"
+    "moji": "🇵🇫",
+    "emoji_order": 1104
   },
   "flag_pg": {
     "unicode": "1F1F5-1F1EC",
@@ -12522,7 +13184,8 @@
       "pg",
       "flag"
     ],
-    "moji": "🇵🇬"
+    "moji": "🇵🇬",
+    "emoji_order": 1189
   },
   "flag_ph": {
     "unicode": "1F1F5-1F1ED",
@@ -12541,7 +13204,8 @@
       "ph",
       "flag"
     ],
-    "moji": "🇵🇭"
+    "moji": "🇵🇭",
+    "emoji_order": 1192
   },
   "flag_pk": {
     "unicode": "1F1F5-1F1F0",
@@ -12559,7 +13223,8 @@
       "pk",
       "flag"
     ],
-    "moji": "🇵🇰"
+    "moji": "🇵🇰",
+    "emoji_order": 1185
   },
   "flag_pl": {
     "unicode": "1F1F5-1F1F1",
@@ -12578,7 +13243,8 @@
       "pl",
       "flag"
     ],
-    "moji": "🇵🇱"
+    "moji": "🇵🇱",
+    "emoji_order": 1193
   },
   "flag_pm": {
     "unicode": "1F1F5-1F1F2",
@@ -12594,7 +13260,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇵🇲"
+    "moji": "🇵🇲",
+    "emoji_order": 1269
   },
   "flag_pn": {
     "unicode": "1F1F5-1F1F3",
@@ -12610,7 +13277,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇵🇳"
+    "moji": "🇵🇳",
+    "emoji_order": 1267
   },
   "flag_pr": {
     "unicode": "1F1F5-1F1F7",
@@ -12628,7 +13296,8 @@
       "pr",
       "flag"
     ],
-    "moji": "🇵🇷"
+    "moji": "🇵🇷",
+    "emoji_order": 1195
   },
   "flag_ps": {
     "unicode": "1F1F5-1F1F8",
@@ -12646,7 +13315,8 @@
       "ps",
       "flag"
     ],
-    "moji": "🇵🇸"
+    "moji": "🇵🇸",
+    "emoji_order": 1187
   },
   "flag_pt": {
     "unicode": "1F1F5-1F1F9",
@@ -12664,7 +13334,8 @@
       "pt",
       "flag"
     ],
-    "moji": "🇵🇹"
+    "moji": "🇵🇹",
+    "emoji_order": 1194
   },
   "flag_pw": {
     "unicode": "1F1F5-1F1FC",
@@ -12683,7 +13354,8 @@
       "pw",
       "flag"
     ],
-    "moji": "🇵🇼"
+    "moji": "🇵🇼",
+    "emoji_order": 1186
   },
   "flag_py": {
     "unicode": "1F1F5-1F1FE",
@@ -12701,7 +13373,8 @@
       "py",
       "flag"
     ],
-    "moji": "🇵🇾"
+    "moji": "🇵🇾",
+    "emoji_order": 1190
   },
   "flag_qa": {
     "unicode": "1F1F6-1F1E6",
@@ -12720,7 +13393,8 @@
       "qa",
       "flag"
     ],
-    "moji": "🇶🇦"
+    "moji": "🇶🇦",
+    "emoji_order": 1196
   },
   "flag_re": {
     "unicode": "1F1F7-1F1EA",
@@ -12736,7 +13410,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇷🇪"
+    "moji": "🇷🇪",
+    "emoji_order": 1256
   },
   "flag_ro": {
     "unicode": "1F1F7-1F1F4",
@@ -12754,7 +13429,8 @@
       "ro",
       "flag"
     ],
-    "moji": "🇷🇴"
+    "moji": "🇷🇴",
+    "emoji_order": 1197
   },
   "flag_rs": {
     "unicode": "1F1F7-1F1F8",
@@ -12773,7 +13449,8 @@
       "rs",
       "flag"
     ],
-    "moji": "🇷🇸"
+    "moji": "🇷🇸",
+    "emoji_order": 1209
   },
   "flag_ru": {
     "unicode": "1F1F7-1F1FA",
@@ -12792,7 +13469,8 @@
       "ru",
       "flag"
     ],
-    "moji": "🇷🇺"
+    "moji": "🇷🇺",
+    "emoji_order": 1198
   },
   "flag_rw": {
     "unicode": "1F1F7-1F1FC",
@@ -12810,7 +13488,8 @@
       "rw",
       "flag"
     ],
-    "moji": "🇷🇼"
+    "moji": "🇷🇼",
+    "emoji_order": 1199
   },
   "flag_sa": {
     "unicode": "1F1F8-1F1E6",
@@ -12830,7 +13509,8 @@
       "sa",
       "flag"
     ],
-    "moji": "🇸🇦"
+    "moji": "🇸🇦",
+    "emoji_order": 1207
   },
   "flag_sb": {
     "unicode": "1F1F8-1F1E7",
@@ -12848,7 +13528,8 @@
       "sb",
       "flag"
     ],
-    "moji": "🇸🇧"
+    "moji": "🇸🇧",
+    "emoji_order": 1215
   },
   "flag_sc": {
     "unicode": "1F1F8-1F1E8",
@@ -12867,7 +13548,8 @@
       "sc",
       "flag"
     ],
-    "moji": "🇸🇨"
+    "moji": "🇸🇨",
+    "emoji_order": 1210
   },
   "flag_sd": {
     "unicode": "1F1F8-1F1E9",
@@ -12886,7 +13568,8 @@
       "sd",
       "flag"
     ],
-    "moji": "🇸🇩"
+    "moji": "🇸🇩",
+    "emoji_order": 1221
   },
   "flag_se": {
     "unicode": "1F1F8-1F1EA",
@@ -12905,7 +13588,8 @@
       "se",
       "flag"
     ],
-    "moji": "🇸🇪"
+    "moji": "🇸🇪",
+    "emoji_order": 1224
   },
   "flag_sg": {
     "unicode": "1F1F8-1F1EC",
@@ -12923,7 +13607,8 @@
       "sg",
       "flag"
     ],
-    "moji": "🇸🇬"
+    "moji": "🇸🇬",
+    "emoji_order": 1212
   },
   "flag_sh": {
     "unicode": "1F1F8-1F1ED",
@@ -12941,7 +13626,8 @@
       "sh",
       "flag"
     ],
-    "moji": "🇸🇭"
+    "moji": "🇸🇭",
+    "emoji_order": 1200
   },
   "flag_si": {
     "unicode": "1F1F8-1F1EE",
@@ -12960,7 +13646,8 @@
       "si",
       "flag"
     ],
-    "moji": "🇸🇮"
+    "moji": "🇸🇮",
+    "emoji_order": 1214
   },
   "flag_sj": {
     "unicode": "1F1F8-1F1EF",
@@ -12976,7 +13663,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇸🇯"
+    "moji": "🇸🇯",
+    "emoji_order": 1274
   },
   "flag_sk": {
     "unicode": "1F1F8-1F1F0",
@@ -12994,7 +13682,8 @@
       "sk",
       "flag"
     ],
-    "moji": "🇸🇰"
+    "moji": "🇸🇰",
+    "emoji_order": 1213
   },
   "flag_sl": {
     "unicode": "1F1F8-1F1F1",
@@ -13012,7 +13701,8 @@
       "sl",
       "flag"
     ],
-    "moji": "🇸🇱"
+    "moji": "🇸🇱",
+    "emoji_order": 1211
   },
   "flag_sm": {
     "unicode": "1F1F8-1F1F2",
@@ -13030,7 +13720,8 @@
       "sm",
       "flag"
     ],
-    "moji": "🇸🇲"
+    "moji": "🇸🇲",
+    "emoji_order": 1205
   },
   "flag_sn": {
     "unicode": "1F1F8-1F1F3",
@@ -13048,7 +13739,8 @@
       "sn",
       "flag"
     ],
-    "moji": "🇸🇳"
+    "moji": "🇸🇳",
+    "emoji_order": 1208
   },
   "flag_so": {
     "unicode": "1F1F8-1F1F4",
@@ -13066,7 +13758,8 @@
       "so",
       "flag"
     ],
-    "moji": "🇸🇴"
+    "moji": "🇸🇴",
+    "emoji_order": 1216
   },
   "flag_sr": {
     "unicode": "1F1F8-1F1F7",
@@ -13084,7 +13777,8 @@
       "sr",
       "flag"
     ],
-    "moji": "🇸🇷"
+    "moji": "🇸🇷",
+    "emoji_order": 1222
   },
   "flag_ss": {
     "unicode": "1F1F8-1F1F8",
@@ -13100,7 +13794,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇸🇸"
+    "moji": "🇸🇸",
+    "emoji_order": 1292
   },
   "flag_st": {
     "unicode": "1F1F8-1F1F9",
@@ -13119,7 +13814,8 @@
       "st",
       "flag"
     ],
-    "moji": "🇸🇹"
+    "moji": "🇸🇹",
+    "emoji_order": 1206
   },
   "flag_sv": {
     "unicode": "1F1F8-1F1FB",
@@ -13137,7 +13833,8 @@
       "sv",
       "flag"
     ],
-    "moji": "🇸🇻"
+    "moji": "🇸🇻",
+    "emoji_order": 1094
   },
   "flag_sx": {
     "unicode": "1F1F8-1F1FD",
@@ -13153,7 +13850,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇸🇽"
+    "moji": "🇸🇽",
+    "emoji_order": 1291
   },
   "flag_sy": {
     "unicode": "1F1F8-1F1FE",
@@ -13171,7 +13869,8 @@
       "sy",
       "flag"
     ],
-    "moji": "🇸🇾"
+    "moji": "🇸🇾",
+    "emoji_order": 1226
   },
   "flag_sz": {
     "unicode": "1F1F8-1F1FF",
@@ -13189,7 +13888,8 @@
       "sz",
       "flag"
     ],
-    "moji": "🇸🇿"
+    "moji": "🇸🇿",
+    "emoji_order": 1223
   },
   "flag_ta": {
     "unicode": "1F1F9-1F1E6",
@@ -13205,7 +13905,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇹🇦"
+    "moji": "🇹🇦",
+    "emoji_order": 1258
   },
   "flag_tc": {
     "unicode": "1F1F9-1F1E8",
@@ -13221,7 +13922,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇹🇨"
+    "moji": "🇹🇨",
+    "emoji_order": 1293
   },
   "flag_td": {
     "unicode": "1F1F9-1F1E9",
@@ -13240,7 +13942,8 @@
       "td",
       "flag"
     ],
-    "moji": "🇹🇩"
+    "moji": "🇹🇩",
+    "emoji_order": 1076
   },
   "flag_tf": {
     "unicode": "1F1F9-1F1EB",
@@ -13256,7 +13959,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇹🇫"
+    "moji": "🇹🇫",
+    "emoji_order": 1287
   },
   "flag_tg": {
     "unicode": "1F1F9-1F1EC",
@@ -13275,7 +13979,8 @@
       "tg",
       "flag"
     ],
-    "moji": "🇹🇬"
+    "moji": "🇹🇬",
+    "emoji_order": 1232
   },
   "flag_th": {
     "unicode": "1F1F9-1F1ED",
@@ -13294,7 +13999,8 @@
       "th",
       "flag"
     ],
-    "moji": "🇹🇭"
+    "moji": "🇹🇭",
+    "emoji_order": 1230
   },
   "flag_tj": {
     "unicode": "1F1F9-1F1EF",
@@ -13313,7 +14019,8 @@
       "tj",
       "flag"
     ],
-    "moji": "🇹🇯"
+    "moji": "🇹🇯",
+    "emoji_order": 1228
   },
   "flag_tk": {
     "unicode": "1F1F9-1F1F0",
@@ -13329,7 +14036,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇹🇰"
+    "moji": "🇹🇰",
+    "emoji_order": 1271
   },
   "flag_tl": {
     "unicode": "1F1F9-1F1F1",
@@ -13347,7 +14055,8 @@
       "tl",
       "flag"
     ],
-    "moji": "🇹🇱"
+    "moji": "🇹🇱",
+    "emoji_order": 1231
   },
   "flag_tm": {
     "unicode": "1F1F9-1F1F2",
@@ -13365,7 +14074,8 @@
       "tm",
       "flag"
     ],
-    "moji": "🇹🇲"
+    "moji": "🇹🇲",
+    "emoji_order": 1237
   },
   "flag_tn": {
     "unicode": "1F1F9-1F1F3",
@@ -13384,7 +14094,8 @@
       "tn",
       "flag"
     ],
-    "moji": "🇹🇳"
+    "moji": "🇹🇳",
+    "emoji_order": 1235
   },
   "flag_to": {
     "unicode": "1F1F9-1F1F4",
@@ -13402,7 +14113,8 @@
       "to",
       "flag"
     ],
-    "moji": "🇹🇴"
+    "moji": "🇹🇴",
+    "emoji_order": 1233
   },
   "flag_tr": {
     "unicode": "1F1F9-1F1F7",
@@ -13420,7 +14132,8 @@
       "turkiye",
       "flag"
     ],
-    "moji": "🇹🇷"
+    "moji": "🇹🇷",
+    "emoji_order": 1236
   },
   "flag_tt": {
     "unicode": "1F1F9-1F1F9",
@@ -13438,7 +14151,8 @@
       "tt",
       "flag"
     ],
-    "moji": "🇹🇹"
+    "moji": "🇹🇹",
+    "emoji_order": 1234
   },
   "flag_tv": {
     "unicode": "1F1F9-1F1FB",
@@ -13456,7 +14170,8 @@
       "tv",
       "flag"
     ],
-    "moji": "🇹🇻"
+    "moji": "🇹🇻",
+    "emoji_order": 1238
   },
   "flag_tw": {
     "unicode": "1F1F9-1F1FC",
@@ -13475,7 +14190,8 @@
       "tw",
       "flag"
     ],
-    "moji": "🇹🇼"
+    "moji": "🇹🇼",
+    "emoji_order": 1227
   },
   "flag_tz": {
     "unicode": "1F1F9-1F1FF",
@@ -13493,7 +14209,8 @@
       "tz",
       "flag"
     ],
-    "moji": "🇹🇿"
+    "moji": "🇹🇿",
+    "emoji_order": 1229
   },
   "flag_ua": {
     "unicode": "1F1FA-1F1E6",
@@ -13512,7 +14229,8 @@
       "ua",
       "flag"
     ],
-    "moji": "🇺🇦"
+    "moji": "🇺🇦",
+    "emoji_order": 1240
   },
   "flag_ug": {
     "unicode": "1F1FA-1F1EC",
@@ -13530,7 +14248,8 @@
       "ug",
       "flag"
     ],
-    "moji": "🇺🇬"
+    "moji": "🇺🇬",
+    "emoji_order": 1239
   },
   "flag_um": {
     "unicode": "1F1FA-1F1F2",
@@ -13546,7 +14265,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇺🇲"
+    "moji": "🇺🇲",
+    "emoji_order": 1275
   },
   "flag_us": {
     "unicode": "1F1FA-1F1F8",
@@ -13569,7 +14289,8 @@
       "us",
       "flag"
     ],
-    "moji": "🇺🇸"
+    "moji": "🇺🇸",
+    "emoji_order": 1243
   },
   "flag_uy": {
     "unicode": "1F1FA-1F1FE",
@@ -13587,7 +14308,8 @@
       "uy",
       "flag"
     ],
-    "moji": "🇺🇾"
+    "moji": "🇺🇾",
+    "emoji_order": 1245
   },
   "flag_uz": {
     "unicode": "1F1FA-1F1FF",
@@ -13606,7 +14328,8 @@
       "uz",
       "flag"
     ],
-    "moji": "🇺🇿"
+    "moji": "🇺🇿",
+    "emoji_order": 1246
   },
   "flag_va": {
     "unicode": "1F1FB-1F1E6",
@@ -13624,7 +14347,8 @@
       "va",
       "flag"
     ],
-    "moji": "🇻🇦"
+    "moji": "🇻🇦",
+    "emoji_order": 1248
   },
   "flag_vc": {
     "unicode": "1F1FB-1F1E8",
@@ -13642,7 +14366,8 @@
       "vc",
       "flag"
     ],
-    "moji": "🇻🇨"
+    "moji": "🇻🇨",
+    "emoji_order": 1203
   },
   "flag_ve": {
     "unicode": "1F1FB-1F1EA",
@@ -13660,7 +14385,8 @@
       "ve",
       "flag"
     ],
-    "moji": "🇻🇪"
+    "moji": "🇻🇪",
+    "emoji_order": 1249
   },
   "flag_vg": {
     "unicode": "1F1FB-1F1EC",
@@ -13676,7 +14402,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇻🇬"
+    "moji": "🇻🇬",
+    "emoji_order": 1282
   },
   "flag_vi": {
     "unicode": "1F1FB-1F1EE",
@@ -13694,7 +14421,8 @@
       "vi",
       "flag"
     ],
-    "moji": "🇻🇮"
+    "moji": "🇻🇮",
+    "emoji_order": 1244
   },
   "flag_vn": {
     "unicode": "1F1FB-1F1F3",
@@ -13713,7 +14441,8 @@
       "vn",
       "flag"
     ],
-    "moji": "🇻🇳"
+    "moji": "🇻🇳",
+    "emoji_order": 1250
   },
   "flag_vu": {
     "unicode": "1F1FB-1F1FA",
@@ -13731,7 +14460,8 @@
       "vu",
       "flag"
     ],
-    "moji": "🇻🇺"
+    "moji": "🇻🇺",
+    "emoji_order": 1247
   },
   "flag_wf": {
     "unicode": "1F1FC-1F1EB",
@@ -13749,7 +14479,8 @@
       "wf",
       "flag"
     ],
-    "moji": "🇼🇫"
+    "moji": "🇼🇫",
+    "emoji_order": 1251
   },
   "flag_white": {
     "unicode": "1F3F3",
@@ -13766,7 +14497,8 @@
       "signal",
       "object"
     ],
-    "moji": "🏳"
+    "moji": "🏳",
+    "emoji_order": 754
   },
   "flag_ws": {
     "unicode": "1F1FC-1F1F8",
@@ -13785,7 +14517,8 @@
       "ws",
       "flag"
     ],
-    "moji": "🇼🇸"
+    "moji": "🇼🇸",
+    "emoji_order": 1204
   },
   "flag_xk": {
     "unicode": "1F1FD-1F1F0",
@@ -13803,7 +14536,8 @@
       "xk",
       "flag"
     ],
-    "moji": "🇽🇰"
+    "moji": "🇽🇰",
+    "emoji_order": 1139
   },
   "flag_ye": {
     "unicode": "1F1FE-1F1EA",
@@ -13822,7 +14556,8 @@
       "ye",
       "flag"
     ],
-    "moji": "🇾🇪"
+    "moji": "🇾🇪",
+    "emoji_order": 1253
   },
   "flag_yt": {
     "unicode": "1F1FE-1F1F9",
@@ -13838,7 +14573,8 @@
       "country",
       "flag"
     ],
-    "moji": "🇾🇹"
+    "moji": "🇾🇹",
+    "emoji_order": 1265
   },
   "flag_za": {
     "unicode": "1F1FF-1F1E6",
@@ -13855,7 +14591,8 @@
       "nation",
       "flag"
     ],
-    "moji": "🇿🇦"
+    "moji": "🇿🇦",
+    "emoji_order": 1217
   },
   "flag_zm": {
     "unicode": "1F1FF-1F1F2",
@@ -13873,7 +14610,8 @@
       "zm",
       "flag"
     ],
-    "moji": "🇿🇲"
+    "moji": "🇿🇲",
+    "emoji_order": 1254
   },
   "flag_zw": {
     "unicode": "1F1FF-1F1FC",
@@ -13891,7 +14629,8 @@
       "zw",
       "flag"
     ],
-    "moji": "🇿🇼"
+    "moji": "🇿🇼",
+    "emoji_order": 1255
   },
   "flags": {
     "unicode": "1F38F",
@@ -13918,7 +14657,8 @@
       "object",
       "japan"
     ],
-    "moji": "🎏"
+    "moji": "🎏",
+    "emoji_order": 692
   },
   "flashlight": {
     "unicode": "1F526",
@@ -13933,7 +14673,8 @@
       "electronics",
       "object"
     ],
-    "moji": "🔦"
+    "moji": "🔦",
+    "emoji_order": 632
   },
   "fleur-de-lis": {
     "unicode": "269C",
@@ -13947,7 +14688,8 @@
       "symbol",
       "object"
     ],
-    "moji": "⚜"
+    "moji": "⚜",
+    "emoji_order": 860
   },
   "floppy_disk": {
     "unicode": "1F4BE",
@@ -13971,7 +14713,8 @@
       "electronics",
       "office"
     ],
-    "moji": "💾"
+    "moji": "💾",
+    "emoji_order": 603
   },
   "flower_playing_cards": {
     "unicode": "1F3B4",
@@ -13992,7 +14735,8 @@
       "object",
       "symbol"
     ],
-    "moji": "🎴"
+    "moji": "🎴",
+    "emoji_order": 1009
   },
   "flushed": {
     "unicode": "1F633",
@@ -14018,7 +14762,8 @@
       "emotion",
       "omg"
     ],
-    "moji": "😳"
+    "moji": "😳",
+    "emoji_order": 36
   },
   "fog": {
     "unicode": "1F32B",
@@ -14036,7 +14781,8 @@
       "sky",
       "cold"
     ],
-    "moji": "🌫"
+    "moji": "🌫",
+    "emoji_order": 346
   },
   "foggy": {
     "unicode": "1F301",
@@ -14059,7 +14805,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🌁"
+    "moji": "🌁",
+    "emoji_order": 536
   },
   "football": {
     "unicode": "1F3C8",
@@ -14080,7 +14827,8 @@
       "american",
       "game"
     ],
-    "moji": "🏈"
+    "moji": "🏈",
+    "emoji_order": 421
   },
   "footprints": {
     "unicode": "1F463",
@@ -14093,7 +14841,8 @@
     "keywords": [
       "feet"
     ],
-    "moji": "👣"
+    "moji": "👣",
+    "emoji_order": 185
   },
   "fork_and_knife": {
     "unicode": "1F374",
@@ -14115,7 +14864,8 @@
       "object",
       "weapon"
     ],
-    "moji": "🍴"
+    "moji": "🍴",
+    "emoji_order": 417
   },
   "fork_knife_plate": {
     "unicode": "1F37D",
@@ -14137,7 +14887,8 @@
       "setting",
       "object"
     ],
-    "moji": "🍽"
+    "moji": "🍽",
+    "emoji_order": 418
   },
   "fountain": {
     "unicode": "26F2",
@@ -14154,7 +14905,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "⛲"
+    "moji": "⛲",
+    "emoji_order": 539
   },
   "four": {
     "moji": "4️⃣",
@@ -14174,7 +14926,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 906
   },
   "four_leaf_clover": {
     "unicode": "1F340",
@@ -14199,7 +14952,8 @@
       "green",
       "sol"
     ],
-    "moji": "🍀"
+    "moji": "🍀",
+    "emoji_order": 286
   },
   "fox": {
     "unicode": "1F98A",
@@ -14212,7 +14966,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦊"
+    "moji": "🦊",
+    "emoji_order": 10130
   },
   "frame_photo": {
     "unicode": "1F5BC",
@@ -14229,7 +14984,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🖼"
+    "moji": "🖼",
+    "emoji_order": 686
   },
   "free": {
     "unicode": "1F193",
@@ -14244,7 +15000,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🆓"
+    "moji": "🆓",
+    "emoji_order": 901
   },
   "french_bread": {
     "unicode": "1F956",
@@ -14257,7 +15014,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥖"
+    "moji": "🥖",
+    "emoji_order": 10143
   },
   "fried_shrimp": {
     "unicode": "1F364",
@@ -14276,7 +15034,8 @@
       "small",
       "fish"
     ],
-    "moji": "🍤"
+    "moji": "🍤",
+    "emoji_order": 375
   },
   "fries": {
     "unicode": "1F35F",
@@ -14297,7 +15056,8 @@
       "idaho",
       "america"
     ],
-    "moji": "🍟"
+    "moji": "🍟",
+    "emoji_order": 378
   },
   "frog": {
     "unicode": "1F438",
@@ -14312,7 +15072,8 @@
       "nature",
       "wildlife"
     ],
-    "moji": "🐸"
+    "moji": "🐸",
+    "emoji_order": 218
   },
   "frowning": {
     "unicode": "1F626",
@@ -14336,7 +15097,8 @@
       "surprised",
       "emotion"
     ],
-    "moji": "😦"
+    "moji": "😦",
+    "emoji_order": 55
   },
   "frowning2": {
     "unicode": "2639",
@@ -14355,7 +15117,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "☹"
+    "moji": "☹",
+    "emoji_order": 44
   },
   "fuelpump": {
     "unicode": "26FD",
@@ -14373,7 +15136,8 @@
       "object",
       "gas pump"
     ],
-    "moji": "⛽"
+    "moji": "⛽",
+    "emoji_order": 526
   },
   "full_moon": {
     "unicode": "1F315",
@@ -14398,7 +15162,8 @@
       "twilight",
       "space"
     ],
-    "moji": "🌕"
+    "moji": "🌕",
+    "emoji_order": 308
   },
   "full_moon_with_face": {
     "unicode": "1F31D",
@@ -14423,7 +15188,8 @@
       "space",
       "goodnight"
     ],
-    "moji": "🌝"
+    "moji": "🌝",
+    "emoji_order": 317
   },
   "game_die": {
     "unicode": "1F3B2",
@@ -14443,7 +15209,8 @@
       "object",
       "boys night"
     ],
-    "moji": "🎲"
+    "moji": "🎲",
+    "emoji_order": 473
   },
   "gear": {
     "unicode": "2699",
@@ -14457,7 +15224,8 @@
       "object",
       "tool"
     ],
-    "moji": "⚙"
+    "moji": "⚙",
+    "emoji_order": 651
   },
   "gem": {
     "unicode": "1F48E",
@@ -14473,7 +15241,8 @@
       "object",
       "gem"
     ],
-    "moji": "💎"
+    "moji": "💎",
+    "emoji_order": 643
   },
   "gay_pride_flag": {
     "unicode": "1F3F3-1F308",
@@ -14510,7 +15279,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♊"
+    "moji": "♊",
+    "emoji_order": 798
   },
   "ghost": {
     "unicode": "1F47B",
@@ -14525,7 +15295,8 @@
       "holidays",
       "monster"
     ],
-    "moji": "👻"
+    "moji": "👻",
+    "emoji_order": 76
   },
   "gift": {
     "unicode": "1F381",
@@ -14548,7 +15319,8 @@
       "holidays",
       "parties"
     ],
-    "moji": "🎁"
+    "moji": "🎁",
+    "emoji_order": 694
   },
   "gift_heart": {
     "unicode": "1F49D",
@@ -14564,7 +15336,8 @@
       "symbol",
       "condolence"
     ],
-    "moji": "💝"
+    "moji": "💝",
+    "emoji_order": 782
   },
   "girl": {
     "unicode": "1F467",
@@ -14582,7 +15355,8 @@
       "baby",
       "diversity"
     ],
-    "moji": "👧"
+    "moji": "👧",
+    "emoji_order": 123
   },
   "girl_tone1": {
     "unicode": "1F467-1F3FB",
@@ -14597,7 +15371,8 @@
       "kid",
       "child"
     ],
-    "moji": "👧🏻"
+    "moji": "👧🏻",
+    "emoji_order": 1435
   },
   "girl_tone2": {
     "unicode": "1F467-1F3FC",
@@ -14612,7 +15387,8 @@
       "kid",
       "child"
     ],
-    "moji": "👧🏼"
+    "moji": "👧🏼",
+    "emoji_order": 1436
   },
   "girl_tone3": {
     "unicode": "1F467-1F3FD",
@@ -14627,7 +15403,8 @@
       "kid",
       "child"
     ],
-    "moji": "👧🏽"
+    "moji": "👧🏽",
+    "emoji_order": 1437
   },
   "girl_tone4": {
     "unicode": "1F467-1F3FE",
@@ -14642,7 +15419,8 @@
       "kid",
       "child"
     ],
-    "moji": "👧🏾"
+    "moji": "👧🏾",
+    "emoji_order": 1438
   },
   "girl_tone5": {
     "unicode": "1F467-1F3FF",
@@ -14657,7 +15435,8 @@
       "kid",
       "child"
     ],
-    "moji": "👧🏿"
+    "moji": "👧🏿",
+    "emoji_order": 1439
   },
   "globe_with_meridians": {
     "unicode": "1F310",
@@ -14678,7 +15457,8 @@
       "home",
       "symbol"
     ],
-    "moji": "🌐"
+    "moji": "🌐",
+    "emoji_order": 875
   },
   "goal": {
     "unicode": "1F945",
@@ -14691,7 +15471,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥅"
+    "moji": "🥅",
+    "emoji_order": 10162
   },
   "goat": {
     "unicode": "1F410",
@@ -14710,7 +15491,8 @@
       "billy",
       "livestock"
     ],
-    "moji": "🐐"
+    "moji": "🐐",
+    "emoji_order": 260
   },
   "golf": {
     "unicode": "26F3",
@@ -14731,7 +15513,8 @@
       "sport",
       "golf"
     ],
-    "moji": "⛳"
+    "moji": "⛳",
+    "emoji_order": 427
   },
   "golfer": {
     "unicode": "1F3CC",
@@ -14753,7 +15536,8 @@
       "vacation",
       "golf"
     ],
-    "moji": "🏌"
+    "moji": "🏌",
+    "emoji_order": 428
   },
   "gorilla": {
     "unicode": "1F98D",
@@ -14764,7 +15548,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦍"
+    "moji": "🦍",
+    "emoji_order": 10133
   },
   "grapes": {
     "unicode": "1F347",
@@ -14783,7 +15568,8 @@
       "cluster",
       "vine"
     ],
-    "moji": "🍇"
+    "moji": "🍇",
+    "emoji_order": 359
   },
   "green_apple": {
     "unicode": "1F34F",
@@ -14804,7 +15590,8 @@
       "core",
       "food"
     ],
-    "moji": "🍏"
+    "moji": "🍏",
+    "emoji_order": 352
   },
   "green_book": {
     "unicode": "1F4D7",
@@ -14822,7 +15609,8 @@
       "office",
       "book"
     ],
-    "moji": "📗"
+    "moji": "📗",
+    "emoji_order": 738
   },
   "green_heart": {
     "unicode": "1F49A",
@@ -14848,7 +15636,8 @@
       "possessive",
       "symbol"
     ],
-    "moji": "💚"
+    "moji": "💚",
+    "emoji_order": 771
   },
   "grey_exclamation": {
     "unicode": "2755",
@@ -14863,7 +15652,8 @@
       "symbol",
       "punctuation"
     ],
-    "moji": "❕"
+    "moji": "❕",
+    "emoji_order": 851
   },
   "grey_question": {
     "unicode": "2754",
@@ -14878,7 +15668,8 @@
       "symbol",
       "punctuation"
     ],
-    "moji": "❔"
+    "moji": "❔",
+    "emoji_order": 853
   },
   "grimacing": {
     "unicode": "1F62C",
@@ -14899,7 +15690,8 @@
       "emotion",
       "selfie"
     ],
-    "moji": "😬"
+    "moji": "😬",
+    "emoji_order": 2
   },
   "grin": {
     "unicode": "1F601",
@@ -14923,7 +15715,8 @@
       "good",
       "selfie"
     ],
-    "moji": "😁"
+    "moji": "😁",
+    "emoji_order": 3
   },
   "grinning": {
     "unicode": "1F600",
@@ -14944,7 +15737,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😀"
+    "moji": "😀",
+    "emoji_order": 1
   },
   "guardsman": {
     "unicode": "1F482",
@@ -14972,7 +15766,8 @@
       "diversity",
       "job"
     ],
-    "moji": "💂"
+    "moji": "💂",
+    "emoji_order": 133
   },
   "guardsman_tone1": {
     "unicode": "1F482-1F3FB",
@@ -14995,7 +15790,8 @@
       "ceremonial",
       "military"
     ],
-    "moji": "💂🏻"
+    "moji": "💂🏻",
+    "emoji_order": 1485
   },
   "guardsman_tone2": {
     "unicode": "1F482-1F3FC",
@@ -15018,7 +15814,8 @@
       "ceremonial",
       "military"
     ],
-    "moji": "💂🏼"
+    "moji": "💂🏼",
+    "emoji_order": 1486
   },
   "guardsman_tone3": {
     "unicode": "1F482-1F3FD",
@@ -15041,7 +15838,8 @@
       "ceremonial",
       "military"
     ],
-    "moji": "💂🏽"
+    "moji": "💂🏽",
+    "emoji_order": 1487
   },
   "guardsman_tone4": {
     "unicode": "1F482-1F3FE",
@@ -15064,7 +15862,8 @@
       "ceremonial",
       "military"
     ],
-    "moji": "💂🏾"
+    "moji": "💂🏾",
+    "emoji_order": 1488
   },
   "guardsman_tone5": {
     "unicode": "1F482-1F3FF",
@@ -15087,7 +15886,8 @@
       "ceremonial",
       "military"
     ],
-    "moji": "💂🏿"
+    "moji": "💂🏿",
+    "emoji_order": 1489
   },
   "guitar": {
     "unicode": "1F3B8",
@@ -15108,7 +15908,8 @@
       "electric",
       "instruments"
     ],
-    "moji": "🎸"
+    "moji": "🎸",
+    "emoji_order": 467
   },
   "gun": {
     "unicode": "1F52B",
@@ -15126,7 +15927,8 @@
       "gun",
       "sarcastic"
     ],
-    "moji": "🔫"
+    "moji": "🔫",
+    "emoji_order": 653
   },
   "haircut": {
     "unicode": "1F487",
@@ -15144,7 +15946,8 @@
       "women",
       "diversity"
     ],
-    "moji": "💇"
+    "moji": "💇",
+    "emoji_order": 153
   },
   "haircut_tone1": {
     "unicode": "1F487-1F3FB",
@@ -15159,7 +15962,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💇🏻"
+    "moji": "💇🏻",
+    "emoji_order": 1560
   },
   "haircut_tone2": {
     "unicode": "1F487-1F3FC",
@@ -15174,7 +15978,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💇🏼"
+    "moji": "💇🏼",
+    "emoji_order": 1561
   },
   "haircut_tone3": {
     "unicode": "1F487-1F3FD",
@@ -15189,7 +15994,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💇🏽"
+    "moji": "💇🏽",
+    "emoji_order": 1562
   },
   "haircut_tone4": {
     "unicode": "1F487-1F3FE",
@@ -15204,7 +16010,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💇🏾"
+    "moji": "💇🏾",
+    "emoji_order": 1563
   },
   "haircut_tone5": {
     "unicode": "1F487-1F3FF",
@@ -15219,7 +16026,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💇🏿"
+    "moji": "💇🏿",
+    "emoji_order": 1564
   },
   "hamburger": {
     "unicode": "1F354",
@@ -15238,7 +16046,8 @@
       "beef",
       "america"
     ],
-    "moji": "🍔"
+    "moji": "🍔",
+    "emoji_order": 377
   },
   "hammer": {
     "unicode": "1F528",
@@ -15259,7 +16068,8 @@
       "tool",
       "weapon"
     ],
-    "moji": "🔨"
+    "moji": "🔨",
+    "emoji_order": 646
   },
   "hammer_pick": {
     "unicode": "2692",
@@ -15276,7 +16086,8 @@
       "tool",
       "weapon"
     ],
-    "moji": "⚒"
+    "moji": "⚒",
+    "emoji_order": 647
   },
   "hamster": {
     "unicode": "1F439",
@@ -15290,7 +16101,8 @@
       "animal",
       "nature"
     ],
-    "moji": "🐹"
+    "moji": "🐹",
+    "emoji_order": 208
   },
   "hand_splayed": {
     "unicode": "1F590",
@@ -15311,7 +16123,8 @@
       "hands",
       "diversity"
     ],
-    "moji": "🖐"
+    "moji": "🖐",
+    "emoji_order": 107
   },
   "hand_splayed_tone1": {
     "unicode": "1F590-1F3FB",
@@ -15329,7 +16142,8 @@
       "stop",
       "halt"
     ],
-    "moji": "🖐🏻"
+    "moji": "🖐🏻",
+    "emoji_order": 1390
   },
   "hand_splayed_tone2": {
     "unicode": "1F590-1F3FC",
@@ -15347,7 +16161,8 @@
       "stop",
       "halt"
     ],
-    "moji": "🖐🏼"
+    "moji": "🖐🏼",
+    "emoji_order": 1391
   },
   "hand_splayed_tone3": {
     "unicode": "1F590-1F3FD",
@@ -15365,7 +16180,8 @@
       "stop",
       "halt"
     ],
-    "moji": "🖐🏽"
+    "moji": "🖐🏽",
+    "emoji_order": 1392
   },
   "hand_splayed_tone4": {
     "unicode": "1F590-1F3FE",
@@ -15383,7 +16199,8 @@
       "stop",
       "halt"
     ],
-    "moji": "🖐🏾"
+    "moji": "🖐🏾",
+    "emoji_order": 1393
   },
   "hand_splayed_tone5": {
     "unicode": "1F590-1F3FF",
@@ -15401,7 +16218,8 @@
       "stop",
       "halt"
     ],
-    "moji": "🖐🏿"
+    "moji": "🖐🏿",
+    "emoji_order": 1394
   },
   "handbag": {
     "unicode": "1F45C",
@@ -15419,7 +16237,8 @@
       "women",
       "vacation"
     ],
-    "moji": "👜"
+    "moji": "👜",
+    "emoji_order": 199
   },
   "handball": {
     "unicode": "1F93E",
@@ -15430,7 +16249,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤾"
+    "moji": "🤾",
+    "emoji_order": 10161
   },
   "handball_tone1": {
     "unicode": "1F93E-1F3FB",
@@ -15441,7 +16261,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤾🏻"
+    "moji": "🤾🏻",
+    "emoji_order": 10090
   },
   "handball_tone2": {
     "unicode": "1F93E-1F3FC",
@@ -15452,7 +16273,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤾🏼"
+    "moji": "🤾🏼",
+    "emoji_order": 10091
   },
   "handball_tone3": {
     "unicode": "1F93E-1F3FD",
@@ -15463,7 +16285,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤾🏽"
+    "moji": "🤾🏽",
+    "emoji_order": 10092
   },
   "handball_tone4": {
     "unicode": "1F93E-1F3FE",
@@ -15474,7 +16297,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤾🏾"
+    "moji": "🤾🏾",
+    "emoji_order": 10093
   },
   "handball_tone5": {
     "unicode": "1F93E-1F3FF",
@@ -15485,7 +16309,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤾🏿"
+    "moji": "🤾🏿",
+    "emoji_order": 10094
   },
   "handshake": {
     "unicode": "1F91D",
@@ -15498,7 +16323,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤝"
+    "moji": "🤝",
+    "emoji_order": 10122
   },
   "handshake_tone1": {
     "unicode": "1F91D-1F3FB",
@@ -15511,7 +16337,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤝🏻"
+    "moji": "🤝🏻",
+    "emoji_order": 10065
   },
   "handshake_tone2": {
     "unicode": "1F91D-1F3FC",
@@ -15524,7 +16351,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤝🏼"
+    "moji": "🤝🏼",
+    "emoji_order": 10066
   },
   "handshake_tone3": {
     "unicode": "1F91D-1F3FD",
@@ -15537,7 +16365,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤝🏽"
+    "moji": "🤝🏽",
+    "emoji_order": 10067
   },
   "handshake_tone4": {
     "unicode": "1F91D-1F3FE",
@@ -15550,7 +16379,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤝🏾"
+    "moji": "🤝🏾",
+    "emoji_order": 10068
   },
   "handshake_tone5": {
     "unicode": "1F91D-1F3FF",
@@ -15563,7 +16393,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤝🏿"
+    "moji": "🤝🏿",
+    "emoji_order": 10069
   },
   "hash": {
     "moji": "#⃣",
@@ -15579,7 +16410,8 @@
     "keywords": [
       "symbol",
       "number"
-    ]
+    ],
+    "emoji_order": 946
   },
   "hatched_chick": {
     "unicode": "1F425",
@@ -15599,7 +16431,8 @@
       "cute",
       "animal"
     ],
-    "moji": "🐥"
+    "moji": "🐥",
+    "emoji_order": 230
   },
   "hatching_chick": {
     "unicode": "1F423",
@@ -15621,7 +16454,8 @@
       "cute",
       "animal"
     ],
-    "moji": "🐣"
+    "moji": "🐣",
+    "emoji_order": 229
   },
   "head_bandage": {
     "unicode": "1F915",
@@ -15639,7 +16473,8 @@
       "sick",
       "emotion"
     ],
-    "moji": "🤕"
+    "moji": "🤕",
+    "emoji_order": 67
   },
   "headphones": {
     "unicode": "1F3A7",
@@ -15662,7 +16497,8 @@
       "listen",
       "instruments"
     ],
-    "moji": "🎧"
+    "moji": "🎧",
+    "emoji_order": 462
   },
   "hear_no_evil": {
     "unicode": "1F649",
@@ -15680,7 +16516,8 @@
       "sound",
       "kikazaru"
     ],
-    "moji": "🙉"
+    "moji": "🙉",
+    "emoji_order": 222
   },
   "heart": {
     "moji": "❤",
@@ -15712,7 +16549,8 @@
       "valentines",
       "symbol",
       "parties"
-    ]
+    ],
+    "emoji_order": 769
   },
   "heart_decoration": {
     "unicode": "1F49F",
@@ -15728,7 +16566,8 @@
       "purple-square",
       "symbol"
     ],
-    "moji": "💟"
+    "moji": "💟",
+    "emoji_order": 783
   },
   "heart_exclamation": {
     "unicode": "2763",
@@ -15746,7 +16585,8 @@
       "symbol",
       "love"
     ],
-    "moji": "❣"
+    "moji": "❣",
+    "emoji_order": 775
   },
   "heart_eyes": {
     "unicode": "1F60D",
@@ -15777,7 +16617,8 @@
       "emotion",
       "beautiful"
     ],
-    "moji": "😍"
+    "moji": "😍",
+    "emoji_order": 17
   },
   "heart_eyes_cat": {
     "unicode": "1F63B",
@@ -15800,7 +16641,8 @@
       "cat",
       "beautiful"
     ],
-    "moji": "😻"
+    "moji": "😻",
+    "emoji_order": 82
   },
   "heartbeat": {
     "unicode": "1F493",
@@ -15817,7 +16659,8 @@
       "valentines",
       "symbol"
     ],
-    "moji": "💓"
+    "moji": "💓",
+    "emoji_order": 778
   },
   "heartpulse": {
     "unicode": "1F497",
@@ -15834,7 +16677,8 @@
       "valentines",
       "symbol"
     ],
-    "moji": "💗"
+    "moji": "💗",
+    "emoji_order": 779
   },
   "hearts": {
     "unicode": "2665",
@@ -15853,7 +16697,8 @@
       "symbol",
       "game"
     ],
-    "moji": "♥"
+    "moji": "♥",
+    "emoji_order": 1007
   },
   "heavy_check_mark": {
     "unicode": "2714",
@@ -15870,7 +16715,8 @@
       "ok",
       "symbol"
     ],
-    "moji": "✔"
+    "moji": "✔",
+    "emoji_order": 957
   },
   "heavy_division_sign": {
     "unicode": "2797",
@@ -15886,7 +16732,8 @@
       "math",
       "symbol"
     ],
-    "moji": "➗"
+    "moji": "➗",
+    "emoji_order": 961
   },
   "heavy_dollar_sign": {
     "unicode": "1F4B2",
@@ -15908,7 +16755,8 @@
       "math",
       "symbol"
     ],
-    "moji": "💲"
+    "moji": "💲",
+    "emoji_order": 963
   },
   "heavy_minus_sign": {
     "unicode": "2796",
@@ -15923,7 +16771,8 @@
       "math",
       "symbol"
     ],
-    "moji": "➖"
+    "moji": "➖",
+    "emoji_order": 960
   },
   "heavy_multiplication_x": {
     "unicode": "2716",
@@ -15940,7 +16789,8 @@
       "math",
       "symbol"
     ],
-    "moji": "✖"
+    "moji": "✖",
+    "emoji_order": 962
   },
   "heavy_plus_sign": {
     "unicode": "2795",
@@ -15955,7 +16805,8 @@
       "math",
       "symbol"
     ],
-    "moji": "➕"
+    "moji": "➕",
+    "emoji_order": 959
   },
   "helicopter": {
     "unicode": "1F681",
@@ -15976,7 +16827,8 @@
       "travel",
       "fly"
     ],
-    "moji": "🚁"
+    "moji": "🚁",
+    "emoji_order": 511
   },
   "helmet_with_cross": {
     "unicode": "26D1",
@@ -15997,7 +16849,8 @@
       "accessories",
       "job"
     ],
-    "moji": "⛑"
+    "moji": "⛑",
+    "emoji_order": 193
   },
   "herb": {
     "unicode": "1F33F",
@@ -16021,7 +16874,8 @@
       "nature",
       "leaf"
     ],
-    "moji": "🌿"
+    "moji": "🌿",
+    "emoji_order": 284
   },
   "hibiscus": {
     "unicode": "1F33A",
@@ -16041,7 +16895,8 @@
       "nature",
       "tropical"
     ],
-    "moji": "🌺"
+    "moji": "🌺",
+    "emoji_order": 293
   },
   "high_brightness": {
     "unicode": "1F506",
@@ -16057,7 +16912,8 @@
       "sun",
       "symbol"
     ],
-    "moji": "🔆"
+    "moji": "🔆",
+    "emoji_order": 858
   },
   "high_heel": {
     "unicode": "1F460",
@@ -16077,7 +16933,8 @@
       "accessories",
       "girls night"
     ],
-    "moji": "👠"
+    "moji": "👠",
+    "emoji_order": 186
   },
   "hockey": {
     "unicode": "1F3D2",
@@ -16092,7 +16949,8 @@
       "sport",
       "hockey"
     ],
-    "moji": "🏒"
+    "moji": "🏒",
+    "emoji_order": 431
   },
   "hole": {
     "unicode": "1F573",
@@ -16107,7 +16965,8 @@
       "well",
       "object"
     ],
-    "moji": "🕳"
+    "moji": "🕳",
+    "emoji_order": 670
   },
   "homes": {
     "unicode": "1F3D8",
@@ -16131,7 +16990,8 @@
       "building",
       "house"
     ],
-    "moji": "🏘"
+    "moji": "🏘",
+    "emoji_order": 566
   },
   "honey_pot": {
     "unicode": "1F36F",
@@ -16151,7 +17011,8 @@
       "food",
       "vagina"
     ],
-    "moji": "🍯"
+    "moji": "🍯",
+    "emoji_order": 370
   },
   "horse": {
     "unicode": "1F434",
@@ -16166,7 +17027,8 @@
       "brown",
       "wildlife"
     ],
-    "moji": "🐴"
+    "moji": "🐴",
+    "emoji_order": 233
   },
   "horse_racing": {
     "unicode": "1F3C7",
@@ -16189,7 +17051,8 @@
       "sport",
       "horse racing"
     ],
-    "moji": "🏇"
+    "moji": "🏇",
+    "emoji_order": 448
   },
   "horse_racing_tone1": {
     "unicode": "1F3C7-1F3FB",
@@ -16207,7 +17070,8 @@
       "jockey",
       "triple crown"
     ],
-    "moji": "🏇🏻"
+    "moji": "🏇🏻",
+    "emoji_order": 1610
   },
   "horse_racing_tone2": {
     "unicode": "1F3C7-1F3FC",
@@ -16225,7 +17089,8 @@
       "jockey",
       "triple crown"
     ],
-    "moji": "🏇🏼"
+    "moji": "🏇🏼",
+    "emoji_order": 1611
   },
   "horse_racing_tone3": {
     "unicode": "1F3C7-1F3FD",
@@ -16243,7 +17108,8 @@
       "jockey",
       "triple crown"
     ],
-    "moji": "🏇🏽"
+    "moji": "🏇🏽",
+    "emoji_order": 1612
   },
   "horse_racing_tone4": {
     "unicode": "1F3C7-1F3FE",
@@ -16261,7 +17127,8 @@
       "jockey",
       "triple crown"
     ],
-    "moji": "🏇🏾"
+    "moji": "🏇🏾",
+    "emoji_order": 1613
   },
   "horse_racing_tone5": {
     "unicode": "1F3C7-1F3FF",
@@ -16279,7 +17146,8 @@
       "jockey",
       "triple crown"
     ],
-    "moji": "🏇🏿"
+    "moji": "🏇🏿",
+    "emoji_order": 1614
   },
   "hospital": {
     "unicode": "1F3E5",
@@ -16297,7 +17165,8 @@
       "places",
       "911"
     ],
-    "moji": "🏥"
+    "moji": "🏥",
+    "emoji_order": 578
   },
   "hot_pepper": {
     "unicode": "1F336",
@@ -16317,7 +17186,8 @@
       "jalapeno",
       "vegetables"
     ],
-    "moji": "🌶"
+    "moji": "🌶",
+    "emoji_order": 367
   },
   "hotdog": {
     "unicode": "1F32D",
@@ -16333,7 +17203,8 @@
       "america",
       "food"
     ],
-    "moji": "🌭"
+    "moji": "🌭",
+    "emoji_order": 379
   },
   "hotel": {
     "unicode": "1F3E8",
@@ -16355,7 +17226,8 @@
       "places",
       "vacation"
     ],
-    "moji": "🏨"
+    "moji": "🏨",
+    "emoji_order": 580
   },
   "hotsprings": {
     "unicode": "2668",
@@ -16373,7 +17245,8 @@
       "warm",
       "symbol"
     ],
-    "moji": "♨"
+    "moji": "♨",
+    "emoji_order": 843
   },
   "hourglass": {
     "unicode": "231B",
@@ -16391,7 +17264,8 @@
       "time",
       "object"
     ],
-    "moji": "⌛"
+    "moji": "⌛",
+    "emoji_order": 627
   },
   "hourglass_flowing_sand": {
     "unicode": "23F3",
@@ -16407,7 +17281,8 @@
       "time",
       "object"
     ],
-    "moji": "⏳"
+    "moji": "⏳",
+    "emoji_order": 626
   },
   "house": {
     "unicode": "1F3E0",
@@ -16429,7 +17304,8 @@
       "craftsman",
       "places"
     ],
-    "moji": "🏠"
+    "moji": "🏠",
+    "emoji_order": 571
   },
   "house_abandoned": {
     "unicode": "1F3DA",
@@ -16458,7 +17334,8 @@
       "building",
       "house"
     ],
-    "moji": "🏚"
+    "moji": "🏚",
+    "emoji_order": 573
   },
   "house_with_garden": {
     "unicode": "1F3E1",
@@ -16476,7 +17353,8 @@
       "building",
       "house"
     ],
-    "moji": "🏡"
+    "moji": "🏡",
+    "emoji_order": 572
   },
   "hugging": {
     "unicode": "1F917",
@@ -16493,7 +17371,8 @@
       "hug",
       "thank you"
     ],
-    "moji": "🤗"
+    "moji": "🤗",
+    "emoji_order": 28
   },
   "hushed": {
     "unicode": "1F62F",
@@ -16514,7 +17393,8 @@
       "surprised",
       "wow"
     ],
-    "moji": "😯"
+    "moji": "😯",
+    "emoji_order": 54
   },
   "ice_cream": {
     "unicode": "1F368",
@@ -16539,7 +17419,8 @@
       "cone",
       "waffle"
     ],
-    "moji": "🍨"
+    "moji": "🍨",
+    "emoji_order": 396
   },
   "ice_skate": {
     "unicode": "26F8",
@@ -16556,7 +17437,8 @@
       "cold",
       "ice skating"
     ],
-    "moji": "⛸"
+    "moji": "⛸",
+    "emoji_order": 437
   },
   "icecream": {
     "unicode": "1F366",
@@ -16581,7 +17463,8 @@
       "cone",
       "yogurt"
     ],
-    "moji": "🍦"
+    "moji": "🍦",
+    "emoji_order": 397
   },
   "id": {
     "unicode": "1F194",
@@ -16598,7 +17481,8 @@
       "symbol",
       "word"
     ],
-    "moji": "🆔"
+    "moji": "🆔",
+    "emoji_order": 808
   },
   "ideograph_advantage": {
     "unicode": "1F250",
@@ -16616,7 +17500,8 @@
       "japan",
       "symbol"
     ],
-    "moji": "🉐"
+    "moji": "🉐",
+    "emoji_order": 825
   },
   "imp": {
     "unicode": "1F47F",
@@ -16636,7 +17521,8 @@
       "monster",
       "wth"
     ],
-    "moji": "👿"
+    "moji": "👿",
+    "emoji_order": 72
   },
   "inbox_tray": {
     "unicode": "1F4E5",
@@ -16652,7 +17538,8 @@
       "work",
       "office"
     ],
-    "moji": "📥"
+    "moji": "📥",
+    "emoji_order": 713
   },
   "incoming_envelope": {
     "unicode": "1F4E8",
@@ -16667,7 +17554,8 @@
       "inbox",
       "object"
     ],
-    "moji": "📨"
+    "moji": "📨",
+    "emoji_order": 703
   },
   "information_desk_person": {
     "unicode": "1F481",
@@ -16694,7 +17582,8 @@
       "women",
       "diversity"
     ],
-    "moji": "💁"
+    "moji": "💁",
+    "emoji_order": 147
   },
   "information_desk_person_tone1": {
     "unicode": "1F481-1F3FB",
@@ -16717,7 +17606,8 @@
       "attitude",
       "snarky"
     ],
-    "moji": "💁🏻"
+    "moji": "💁🏻",
+    "emoji_order": 1530
   },
   "information_desk_person_tone2": {
     "unicode": "1F481-1F3FC",
@@ -16740,7 +17630,8 @@
       "attitude",
       "snarky"
     ],
-    "moji": "💁🏼"
+    "moji": "💁🏼",
+    "emoji_order": 1531
   },
   "information_desk_person_tone3": {
     "unicode": "1F481-1F3FD",
@@ -16763,7 +17654,8 @@
       "attitude",
       "snarky"
     ],
-    "moji": "💁🏽"
+    "moji": "💁🏽",
+    "emoji_order": 1532
   },
   "information_desk_person_tone4": {
     "unicode": "1F481-1F3FE",
@@ -16786,7 +17678,8 @@
       "attitude",
       "snarky"
     ],
-    "moji": "💁🏾"
+    "moji": "💁🏾",
+    "emoji_order": 1533
   },
   "information_desk_person_tone5": {
     "unicode": "1F481-1F3FF",
@@ -16809,7 +17702,8 @@
       "attitude",
       "snarky"
     ],
-    "moji": "💁🏿"
+    "moji": "💁🏿",
+    "emoji_order": 1534
   },
   "information_source": {
     "unicode": "2139",
@@ -16827,7 +17721,8 @@
       "letter",
       "symbol"
     ],
-    "moji": "ℹ"
+    "moji": "ℹ",
+    "emoji_order": 948
   },
   "innocent": {
     "unicode": "1F607",
@@ -16862,7 +17757,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😇"
+    "moji": "😇",
+    "emoji_order": 9
   },
   "interrobang": {
     "unicode": "2049",
@@ -16880,7 +17776,8 @@
       "wat",
       "symbol"
     ],
-    "moji": "⁉"
+    "moji": "⁉",
+    "emoji_order": 855
   },
   "iphone": {
     "unicode": "1F4F1",
@@ -16899,7 +17796,8 @@
       "phone",
       "selfie"
     ],
-    "moji": "📱"
+    "moji": "📱",
+    "emoji_order": 592
   },
   "island": {
     "unicode": "1F3DD",
@@ -16922,7 +17820,8 @@
       "beach",
       "swim"
     ],
-    "moji": "🏝"
+    "moji": "🏝",
+    "emoji_order": 555
   },
   "izakaya_lantern": {
     "unicode": "1F3EE",
@@ -16945,7 +17844,8 @@
       "object",
       "japan"
     ],
-    "moji": "🏮"
+    "moji": "🏮",
+    "emoji_order": 700
   },
   "jack_o_lantern": {
     "unicode": "1F383",
@@ -16973,7 +17873,8 @@
       "dead",
       "holidays"
     ],
-    "moji": "🎃"
+    "moji": "🎃",
+    "emoji_order": 302
   },
   "japan": {
     "unicode": "1F5FE",
@@ -16991,7 +17892,8 @@
       "vacation",
       "tropical"
     ],
-    "moji": "🗾"
+    "moji": "🗾",
+    "emoji_order": 545
   },
   "japanese_castle": {
     "unicode": "1F3EF",
@@ -17015,7 +17917,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🏯"
+    "moji": "🏯",
+    "emoji_order": 568
   },
   "japanese_goblin": {
     "unicode": "1F47A",
@@ -17044,7 +17947,8 @@
       "angry",
       "monster"
     ],
-    "moji": "👺"
+    "moji": "👺",
+    "emoji_order": 74
   },
   "japanese_ogre": {
     "unicode": "1F479",
@@ -17068,7 +17972,8 @@
       "horns",
       "teeth"
     ],
-    "moji": "👹"
+    "moji": "👹",
+    "emoji_order": 73
   },
   "jeans": {
     "unicode": "1F456",
@@ -17091,7 +17996,8 @@
       "work",
       "skinny"
     ],
-    "moji": "👖"
+    "moji": "👖",
+    "emoji_order": 178
   },
   "joy": {
     "unicode": "1F602",
@@ -17118,7 +18024,8 @@
       "emotion",
       "sarcastic"
     ],
-    "moji": "😂"
+    "moji": "😂",
+    "emoji_order": 4
   },
   "joy_cat": {
     "unicode": "1F639",
@@ -17141,7 +18048,8 @@
       "cat",
       "sarcastic"
     ],
-    "moji": "😹"
+    "moji": "😹",
+    "emoji_order": 81
   },
   "joystick": {
     "unicode": "1F579",
@@ -17159,7 +18067,8 @@
       "game",
       "boys night"
     ],
-    "moji": "🕹"
+    "moji": "🕹",
+    "emoji_order": 600
   },
   "juggling": {
     "unicode": "1F939",
@@ -17172,7 +18081,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤹"
+    "moji": "🤹",
+    "emoji_order": 10156
   },
   "juggling_tone1": {
     "unicode": "1F939-1F3FB",
@@ -17185,7 +18095,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤹🏻"
+    "moji": "🤹🏻",
+    "emoji_order": 10095
   },
   "juggling_tone2": {
     "unicode": "1F939-1F3FC",
@@ -17198,7 +18109,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤹🏼"
+    "moji": "🤹🏼",
+    "emoji_order": 10096
   },
   "juggling_tone3": {
     "unicode": "1F939-1F3FD",
@@ -17211,7 +18123,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤹🏽"
+    "moji": "🤹🏽",
+    "emoji_order": 10097
   },
   "juggling_tone4": {
     "unicode": "1F939-1F3FE",
@@ -17224,7 +18137,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤹🏾"
+    "moji": "🤹🏾",
+    "emoji_order": 10098
   },
   "juggling_tone5": {
     "unicode": "1F939-1F3FF",
@@ -17237,7 +18151,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤹🏿"
+    "moji": "🤹🏿",
+    "emoji_order": 10099
   },
   "kaaba": {
     "unicode": "1F54B",
@@ -17253,7 +18168,8 @@
       "building",
       "condolence"
     ],
-    "moji": "🕋"
+    "moji": "🕋",
+    "emoji_order": 589
   },
   "key": {
     "unicode": "1F511",
@@ -17269,7 +18185,8 @@
       "password",
       "object"
     ],
-    "moji": "🔑"
+    "moji": "🔑",
+    "emoji_order": 679
   },
   "key2": {
     "unicode": "1F5DD",
@@ -17288,7 +18205,8 @@
       "skeleton",
       "object"
     ],
-    "moji": "🗝"
+    "moji": "🗝",
+    "emoji_order": 680
   },
   "keyboard": {
     "unicode": "2328",
@@ -17305,7 +18223,8 @@
       "work",
       "office"
     ],
-    "moji": "⌨"
+    "moji": "⌨",
+    "emoji_order": 595
   },
   "kimono": {
     "unicode": "1F458",
@@ -17322,7 +18241,8 @@
       "japanese",
       "women"
     ],
-    "moji": "👘"
+    "moji": "👘",
+    "emoji_order": 182
   },
   "kiss": {
     "unicode": "1F48B",
@@ -17345,7 +18265,8 @@
       "beautiful",
       "girls night"
     ],
-    "moji": "💋"
+    "moji": "💋",
+    "emoji_order": 184
   },
   "kiss_mm": {
     "unicode": "1F468-2764-1F48B-1F468",
@@ -17372,7 +18293,8 @@
       "sex",
       "lgbt"
     ],
-    "moji": "👨‍❤️‍💋‍👨"
+    "moji": "👨‍❤️‍💋‍👨",
+    "emoji_order": 160
   },
   "kiss_ww": {
     "unicode": "1F469-2764-1F48B-1F469",
@@ -17399,7 +18321,8 @@
       "lgbt",
       "lesbian"
     ],
-    "moji": "👩‍❤️‍💋‍👩"
+    "moji": "👩‍❤️‍💋‍👩",
+    "emoji_order": 159
   },
   "kissing": {
     "unicode": "1F617",
@@ -17424,7 +18347,8 @@
       "smiley",
       "sexy"
     ],
-    "moji": "😗"
+    "moji": "😗",
+    "emoji_order": 19
   },
   "kissing_cat": {
     "unicode": "1F63D",
@@ -17444,7 +18368,8 @@
       "love",
       "cat"
     ],
-    "moji": "😽"
+    "moji": "😽",
+    "emoji_order": 84
   },
   "kissing_closed_eyes": {
     "unicode": "1F61A",
@@ -17470,7 +18395,8 @@
       "smiley",
       "sexy"
     ],
-    "moji": "😚"
+    "moji": "😚",
+    "emoji_order": 21
   },
   "kissing_heart": {
     "unicode": "1F618",
@@ -17499,7 +18425,8 @@
       "smiley",
       "sexy"
     ],
-    "moji": "😘"
+    "moji": "😘",
+    "emoji_order": 18
   },
   "kissing_smiling_eyes": {
     "unicode": "1F619",
@@ -17523,7 +18450,8 @@
       "smiley",
       "sexy"
     ],
-    "moji": "😙"
+    "moji": "😙",
+    "emoji_order": 20
   },
   "kiwi": {
     "unicode": "1F95D",
@@ -17536,7 +18464,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥝"
+    "moji": "🥝",
+    "emoji_order": 10173
   },
   "knife": {
     "unicode": "1F52A",
@@ -17550,7 +18479,8 @@
       "object",
       "weapon"
     ],
-    "moji": "🔪"
+    "moji": "🔪",
+    "emoji_order": 655
   },
   "koala": {
     "unicode": "1F428",
@@ -17565,7 +18495,8 @@
       "nature",
       "wildlife"
     ],
-    "moji": "🐨"
+    "moji": "🐨",
+    "emoji_order": 212
   },
   "koko": {
     "unicode": "1F201",
@@ -17583,7 +18514,8 @@
       "katakana",
       "symbol"
     ],
-    "moji": "🈁"
+    "moji": "🈁",
+    "emoji_order": 895
   },
   "label": {
     "unicode": "1F3F7",
@@ -17597,7 +18529,8 @@
       "tag",
       "object"
     ],
-    "moji": "🏷"
+    "moji": "🏷",
+    "emoji_order": 674
   },
   "large_blue_circle": {
     "unicode": "1F535",
@@ -17612,7 +18545,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "🔵"
+    "moji": "🔵",
+    "emoji_order": 978
   },
   "large_blue_diamond": {
     "unicode": "1F537",
@@ -17627,7 +18561,8 @@
       "shapes",
       "symbol"
     ],
-    "moji": "🔷"
+    "moji": "🔷",
+    "emoji_order": 982
   },
   "large_orange_diamond": {
     "unicode": "1F536",
@@ -17642,7 +18577,8 @@
       "shapes",
       "symbol"
     ],
-    "moji": "🔶"
+    "moji": "🔶",
+    "emoji_order": 981
   },
   "last_quarter_moon": {
     "unicode": "1F317",
@@ -17663,7 +18599,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌗"
+    "moji": "🌗",
+    "emoji_order": 310
   },
   "last_quarter_moon_with_face": {
     "unicode": "1F31C",
@@ -17686,7 +18623,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌜"
+    "moji": "🌜",
+    "emoji_order": 319
   },
   "laughing": {
     "unicode": "1F606",
@@ -17713,7 +18651,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😆"
+    "moji": "😆",
+    "emoji_order": 8
   },
   "leaves": {
     "unicode": "1F343",
@@ -17736,7 +18675,8 @@
       "float",
       "fluttering"
     ],
-    "moji": "🍃"
+    "moji": "🍃",
+    "emoji_order": 289
   },
   "ledger": {
     "unicode": "1F4D2",
@@ -17753,7 +18693,8 @@
       "office",
       "write"
     ],
-    "moji": "📒"
+    "moji": "📒",
+    "emoji_order": 742
   },
   "left_facing_fist": {
     "unicode": "1F91B",
@@ -17766,7 +18707,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤛"
+    "moji": "🤛",
+    "emoji_order": 10120
   },
   "left_facing_fist_tone1": {
     "unicode": "1F91B-1F3FB",
@@ -17779,7 +18721,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤛🏻"
+    "moji": "🤛🏻",
+    "emoji_order": 10050
   },
   "left_facing_fist_tone2": {
     "unicode": "1F91B-1F3FC",
@@ -17792,7 +18735,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤛🏼"
+    "moji": "🤛🏼",
+    "emoji_order": 10051
   },
   "left_facing_fist_tone3": {
     "unicode": "1F91B-1F3FD",
@@ -17805,7 +18749,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤛🏽"
+    "moji": "🤛🏽",
+    "emoji_order": 10052
   },
   "left_facing_fist_tone4": {
     "unicode": "1F91B-1F3FE",
@@ -17818,7 +18763,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤛🏾"
+    "moji": "🤛🏾",
+    "emoji_order": 10053
   },
   "left_facing_fist_tone5": {
     "unicode": "1F91B-1F3FF",
@@ -17831,7 +18777,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤛🏿"
+    "moji": "🤛🏿",
+    "emoji_order": 10054
   },
   "left_luggage": {
     "unicode": "1F6C5",
@@ -17849,7 +18796,8 @@
       "luggage",
       "symbol"
     ],
-    "moji": "🛅"
+    "moji": "🛅",
+    "emoji_order": 882
   },
   "left_right_arrow": {
     "unicode": "2194",
@@ -17866,7 +18814,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "↔"
+    "moji": "↔",
+    "emoji_order": 940
   },
   "leftwards_arrow_with_hook": {
     "unicode": "21A9",
@@ -17882,7 +18831,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "↩"
+    "moji": "↩",
+    "emoji_order": 943
   },
   "lemon": {
     "unicode": "1F34B",
@@ -17900,7 +18850,8 @@
       "citrus",
       "food"
     ],
-    "moji": "🍋"
+    "moji": "🍋",
+    "emoji_order": 356
   },
   "leo": {
     "unicode": "264C",
@@ -17925,7 +18876,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♌"
+    "moji": "♌",
+    "emoji_order": 800
   },
   "leopard": {
     "unicode": "1F406",
@@ -17946,7 +18898,8 @@
       "wildlife",
       "roar"
     ],
-    "moji": "🐆"
+    "moji": "🐆",
+    "emoji_order": 252
   },
   "level_slider": {
     "unicode": "1F39A",
@@ -17959,7 +18912,8 @@
     "keywords": [
       "controls"
     ],
-    "moji": "🎚"
+    "moji": "🎚",
+    "emoji_order": 620
   },
   "levitate": {
     "unicode": "1F574",
@@ -17977,7 +18931,8 @@
       "men",
       "job"
     ],
-    "moji": "🕴"
+    "moji": "🕴",
+    "emoji_order": 449
   },
   "libra": {
     "unicode": "264E",
@@ -18002,7 +18957,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♎"
+    "moji": "♎",
+    "emoji_order": 802
   },
   "lifter": {
     "unicode": "1F3CB",
@@ -18027,7 +18983,8 @@
       "win",
       "diversity"
     ],
-    "moji": "🏋"
+    "moji": "🏋",
+    "emoji_order": 445
   },
   "lifter_tone1": {
     "unicode": "1F3CB-1F3FB",
@@ -18045,7 +19002,8 @@
       "squats",
       "deadlift"
     ],
-    "moji": "🏋🏻"
+    "moji": "🏋🏻",
+    "emoji_order": 1595
   },
   "lifter_tone2": {
     "unicode": "1F3CB-1F3FC",
@@ -18063,7 +19021,8 @@
       "squats",
       "deadlift"
     ],
-    "moji": "🏋🏼"
+    "moji": "🏋🏼",
+    "emoji_order": 1596
   },
   "lifter_tone3": {
     "unicode": "1F3CB-1F3FD",
@@ -18081,7 +19040,8 @@
       "squats",
       "deadlift"
     ],
-    "moji": "🏋🏽"
+    "moji": "🏋🏽",
+    "emoji_order": 1597
   },
   "lifter_tone4": {
     "unicode": "1F3CB-1F3FE",
@@ -18099,7 +19059,8 @@
       "squats",
       "deadlift"
     ],
-    "moji": "🏋🏾"
+    "moji": "🏋🏾",
+    "emoji_order": 1598
   },
   "lifter_tone5": {
     "unicode": "1F3CB-1F3FF",
@@ -18117,7 +19078,8 @@
       "squats",
       "deadlift"
     ],
-    "moji": "🏋🏿"
+    "moji": "🏋🏿",
+    "emoji_order": 1599
   },
   "light_rail": {
     "unicode": "1F688",
@@ -18135,7 +19097,8 @@
       "light",
       "travel"
     ],
-    "moji": "🚈"
+    "moji": "🚈",
+    "emoji_order": 504
   },
   "link": {
     "unicode": "1F517",
@@ -18151,7 +19114,8 @@
       "symbol",
       "office"
     ],
-    "moji": "🔗"
+    "moji": "🔗",
+    "emoji_order": 745
   },
   "lion_face": {
     "unicode": "1F981",
@@ -18169,7 +19133,8 @@
       "cat",
       "animal"
     ],
-    "moji": "🦁"
+    "moji": "🦁",
+    "emoji_order": 214
   },
   "lips": {
     "unicode": "1F444",
@@ -18187,7 +19152,8 @@
       "sexy",
       "lip"
     ],
-    "moji": "👄"
+    "moji": "👄",
+    "emoji_order": 112
   },
   "lipstick": {
     "unicode": "1F484",
@@ -18206,7 +19172,8 @@
       "sexy",
       "lip"
     ],
-    "moji": "💄"
+    "moji": "💄",
+    "emoji_order": 183
   },
   "lizard": {
     "unicode": "1F98E",
@@ -18217,7 +19184,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦎"
+    "moji": "🦎",
+    "emoji_order": 10134
   },
   "lock": {
     "unicode": "1F512",
@@ -18233,7 +19201,8 @@
       "object",
       "lock"
     ],
-    "moji": "🔒"
+    "moji": "🔒",
+    "emoji_order": 757
   },
   "lock_with_ink_pen": {
     "unicode": "1F50F",
@@ -18249,7 +19218,8 @@
       "object",
       "lock"
     ],
-    "moji": "🔏"
+    "moji": "🔏",
+    "emoji_order": 759
   },
   "lollipop": {
     "unicode": "1F36D",
@@ -18270,7 +19240,8 @@
       "sugar",
       "halloween"
     ],
-    "moji": "🍭"
+    "moji": "🍭",
+    "emoji_order": 402
   },
   "loop": {
     "unicode": "27BF",
@@ -18284,7 +19255,8 @@
       "curly",
       "symbol"
     ],
-    "moji": "➿"
+    "moji": "➿",
+    "emoji_order": 874
   },
   "loud_sound": {
     "unicode": "1F50A",
@@ -18298,7 +19270,8 @@
       "alarm",
       "symbol"
     ],
-    "moji": "🔊"
+    "moji": "🔊",
+    "emoji_order": 997
   },
   "loudspeaker": {
     "unicode": "1F4E2",
@@ -18315,7 +19288,8 @@
       "alarm",
       "symbol"
     ],
-    "moji": "📢"
+    "moji": "📢",
+    "emoji_order": 1000
   },
   "love_hotel": {
     "unicode": "1F3E9",
@@ -18342,7 +19316,8 @@
       "places",
       "building"
     ],
-    "moji": "🏩"
+    "moji": "🏩",
+    "emoji_order": 583
   },
   "love_letter": {
     "unicode": "1F48C",
@@ -18364,7 +19339,8 @@
       "heart",
       "object"
     ],
-    "moji": "💌"
+    "moji": "💌",
+    "emoji_order": 705
   },
   "low_brightness": {
     "unicode": "1F505",
@@ -18379,7 +19355,8 @@
       "sun",
       "symbol"
     ],
-    "moji": "🔅"
+    "moji": "🔅",
+    "emoji_order": 857
   },
   "lying_face": {
     "unicode": "1F925",
@@ -18392,7 +19369,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤥"
+    "moji": "🤥",
+    "emoji_order": 10108
   },
   "m": {
     "unicode": "24C2",
@@ -18410,7 +19388,8 @@
       "letter",
       "symbol"
     ],
-    "moji": "Ⓜ"
+    "moji": "Ⓜ",
+    "emoji_order": 876
   },
   "mag": {
     "unicode": "1F50D",
@@ -18429,7 +19408,8 @@
       "details",
       "object"
     ],
-    "moji": "🔍"
+    "moji": "🔍",
+    "emoji_order": 767
   },
   "mag_right": {
     "unicode": "1F50E",
@@ -18448,7 +19428,8 @@
       "details",
       "object"
     ],
-    "moji": "🔎"
+    "moji": "🔎",
+    "emoji_order": 768
   },
   "mahjong": {
     "unicode": "1F004",
@@ -18467,7 +19448,8 @@
       "object",
       "symbol"
     ],
-    "moji": "🀄"
+    "moji": "🀄",
+    "emoji_order": 1004
   },
   "mailbox": {
     "unicode": "1F4EB",
@@ -18483,7 +19465,8 @@
       "inbox",
       "object"
     ],
-    "moji": "📫"
+    "moji": "📫",
+    "emoji_order": 708
   },
   "mailbox_closed": {
     "unicode": "1F4EA",
@@ -18500,7 +19483,8 @@
       "object",
       "office"
     ],
-    "moji": "📪"
+    "moji": "📪",
+    "emoji_order": 707
   },
   "mailbox_with_mail": {
     "unicode": "1F4EC",
@@ -18516,7 +19500,8 @@
       "inbox",
       "object"
     ],
-    "moji": "📬"
+    "moji": "📬",
+    "emoji_order": 709
   },
   "mailbox_with_no_mail": {
     "unicode": "1F4ED",
@@ -18531,7 +19516,8 @@
       "inbox",
       "object"
     ],
-    "moji": "📭"
+    "moji": "📭",
+    "emoji_order": 710
   },
   "man": {
     "unicode": "1F468",
@@ -18554,7 +19540,8 @@
       "selfie",
       "boys night"
     ],
-    "moji": "👨"
+    "moji": "👨",
+    "emoji_order": 124
   },
   "man_dancing": {
     "unicode": "1F57A",
@@ -18567,7 +19554,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🕺"
+    "moji": "🕺",
+    "emoji_order": 10117
   },
   "man_dancing_tone1": {
     "unicode": "1F57A-1F3FB",
@@ -18580,7 +19568,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🕺🏻"
+    "moji": "🕺🏻",
+    "emoji_order": 10030
   },
   "man_dancing_tone2": {
     "unicode": "1F57A-1F3FC",
@@ -18593,7 +19582,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🕺🏼"
+    "moji": "🕺🏼",
+    "emoji_order": 10031
   },
   "man_dancing_tone3": {
     "unicode": "1F57A-1F3FD",
@@ -18606,7 +19596,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🕺🏽"
+    "moji": "🕺🏽",
+    "emoji_order": 10032
   },
   "man_dancing_tone4": {
     "unicode": "1F57A-1F3FE",
@@ -18619,7 +19610,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🕺🏾"
+    "moji": "🕺🏾",
+    "emoji_order": 10033
   },
   "man_dancing_tone5": {
     "unicode": "1F57A-1F3FF",
@@ -18632,7 +19624,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🕺🏿"
+    "moji": "🕺🏿",
+    "emoji_order": 10034
   },
   "man_in_tuxedo": {
     "unicode": "1F935",
@@ -18643,7 +19636,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤵"
+    "moji": "🤵",
+    "emoji_order": 10111
   },
   "man_in_tuxedo_tone1": {
     "unicode": "1F935-1F3FB",
@@ -18656,7 +19650,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤵🏻"
+    "moji": "🤵🏻",
+    "emoji_order": 10010
   },
   "man_in_tuxedo_tone2": {
     "unicode": "1F935-1F3FC",
@@ -18669,7 +19664,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤵🏼"
+    "moji": "🤵🏼",
+    "emoji_order": 10011
   },
   "man_in_tuxedo_tone3": {
     "unicode": "1F935-1F3FD",
@@ -18682,7 +19678,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤵🏽"
+    "moji": "🤵🏽",
+    "emoji_order": 10012
   },
   "man_in_tuxedo_tone4": {
     "unicode": "1F935-1F3FE",
@@ -18695,7 +19692,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤵🏾"
+    "moji": "🤵🏾",
+    "emoji_order": 10013
   },
   "man_in_tuxedo_tone5": {
     "unicode": "1F935-1F3FF",
@@ -18708,7 +19706,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤵🏿"
+    "moji": "🤵🏿",
+    "emoji_order": 10014
   },
   "man_tone1": {
     "unicode": "1F468-1F3FB",
@@ -18725,7 +19724,8 @@
       "guy",
       "mustache"
     ],
-    "moji": "👨🏻"
+    "moji": "👨🏻",
+    "emoji_order": 1440
   },
   "man_tone2": {
     "unicode": "1F468-1F3FC",
@@ -18742,7 +19742,8 @@
       "guy",
       "mustache"
     ],
-    "moji": "👨🏼"
+    "moji": "👨🏼",
+    "emoji_order": 1441
   },
   "man_tone3": {
     "unicode": "1F468-1F3FD",
@@ -18759,7 +19760,8 @@
       "guy",
       "mustache"
     ],
-    "moji": "👨🏽"
+    "moji": "👨🏽",
+    "emoji_order": 1442
   },
   "man_tone4": {
     "unicode": "1F468-1F3FE",
@@ -18776,7 +19778,8 @@
       "guy",
       "mustache"
     ],
-    "moji": "👨🏾"
+    "moji": "👨🏾",
+    "emoji_order": 1443
   },
   "man_tone5": {
     "unicode": "1F468-1F3FF",
@@ -18793,7 +19796,8 @@
       "guy",
       "mustache"
     ],
-    "moji": "👨🏿"
+    "moji": "👨🏿",
+    "emoji_order": 1444
   },
   "man_with_gua_pi_mao": {
     "unicode": "1F472",
@@ -18815,7 +19819,8 @@
       "men",
       "diversity"
     ],
-    "moji": "👲"
+    "moji": "👲",
+    "emoji_order": 129
   },
   "man_with_gua_pi_mao_tone1": {
     "unicode": "1F472-1F3FB",
@@ -18833,7 +19838,8 @@
       "asian",
       "qing"
     ],
-    "moji": "👲🏻"
+    "moji": "👲🏻",
+    "emoji_order": 1465
   },
   "man_with_gua_pi_mao_tone2": {
     "unicode": "1F472-1F3FC",
@@ -18851,7 +19857,8 @@
       "asian",
       "qing"
     ],
-    "moji": "👲🏼"
+    "moji": "👲🏼",
+    "emoji_order": 1466
   },
   "man_with_gua_pi_mao_tone3": {
     "unicode": "1F472-1F3FD",
@@ -18869,7 +19876,8 @@
       "asian",
       "qing"
     ],
-    "moji": "👲🏽"
+    "moji": "👲🏽",
+    "emoji_order": 1467
   },
   "man_with_gua_pi_mao_tone4": {
     "unicode": "1F472-1F3FE",
@@ -18887,7 +19895,8 @@
       "asian",
       "qing"
     ],
-    "moji": "👲🏾"
+    "moji": "👲🏾",
+    "emoji_order": 1468
   },
   "man_with_gua_pi_mao_tone5": {
     "unicode": "1F472-1F3FF",
@@ -18905,7 +19914,8 @@
       "asian",
       "qing"
     ],
-    "moji": "👲🏿"
+    "moji": "👲🏿",
+    "emoji_order": 1469
   },
   "man_with_turban": {
     "unicode": "1F473",
@@ -18930,7 +19940,8 @@
       "hat",
       "diversity"
     ],
-    "moji": "👳"
+    "moji": "👳",
+    "emoji_order": 130
   },
   "man_with_turban_tone1": {
     "unicode": "1F473-1F3FB",
@@ -18951,7 +19962,8 @@
       "wisdom",
       "peace"
     ],
-    "moji": "👳🏻"
+    "moji": "👳🏻",
+    "emoji_order": 1470
   },
   "man_with_turban_tone2": {
     "unicode": "1F473-1F3FC",
@@ -18972,7 +19984,8 @@
       "wisdom",
       "peace"
     ],
-    "moji": "👳🏼"
+    "moji": "👳🏼",
+    "emoji_order": 1471
   },
   "man_with_turban_tone3": {
     "unicode": "1F473-1F3FD",
@@ -18993,7 +20006,8 @@
       "wisdom",
       "peace"
     ],
-    "moji": "👳🏽"
+    "moji": "👳🏽",
+    "emoji_order": 1472
   },
   "man_with_turban_tone4": {
     "unicode": "1F473-1F3FE",
@@ -19014,7 +20028,8 @@
       "wisdom",
       "peace"
     ],
-    "moji": "👳🏾"
+    "moji": "👳🏾",
+    "emoji_order": 1473
   },
   "man_with_turban_tone5": {
     "unicode": "1F473-1F3FF",
@@ -19035,7 +20050,8 @@
       "wisdom",
       "peace"
     ],
-    "moji": "👳🏿"
+    "moji": "👳🏿",
+    "emoji_order": 1474
   },
   "mans_shoe": {
     "unicode": "1F45E",
@@ -19051,7 +20067,8 @@
       "shoe",
       "accessories"
     ],
-    "moji": "👞"
+    "moji": "👞",
+    "emoji_order": 189
   },
   "map": {
     "unicode": "1F5FA",
@@ -19071,7 +20088,8 @@
       "map",
       "vacation"
     ],
-    "moji": "🗺"
+    "moji": "🗺",
+    "emoji_order": 687
   },
   "maple_leaf": {
     "unicode": "1F341",
@@ -19091,7 +20109,8 @@
       "syrup",
       "tree"
     ],
-    "moji": "🍁"
+    "moji": "🍁",
+    "emoji_order": 291
   },
   "martial_arts_uniform": {
     "unicode": "1F94B",
@@ -19104,7 +20123,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥋"
+    "moji": "🥋",
+    "emoji_order": 10159
   },
   "mask": {
     "unicode": "1F637",
@@ -19126,7 +20146,8 @@
       "dead",
       "health"
     ],
-    "moji": "😷"
+    "moji": "😷",
+    "emoji_order": 65
   },
   "massage": {
     "unicode": "1F486",
@@ -19144,7 +20165,8 @@
       "women",
       "diversity"
     ],
-    "moji": "💆"
+    "moji": "💆",
+    "emoji_order": 154
   },
   "massage_tone1": {
     "unicode": "1F486-1F3FB",
@@ -19159,7 +20181,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💆🏻"
+    "moji": "💆🏻",
+    "emoji_order": 1565
   },
   "massage_tone2": {
     "unicode": "1F486-1F3FC",
@@ -19174,7 +20197,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💆🏼"
+    "moji": "💆🏼",
+    "emoji_order": 1566
   },
   "massage_tone3": {
     "unicode": "1F486-1F3FD",
@@ -19189,7 +20213,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💆🏽"
+    "moji": "💆🏽",
+    "emoji_order": 1567
   },
   "massage_tone4": {
     "unicode": "1F486-1F3FE",
@@ -19204,7 +20229,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💆🏾"
+    "moji": "💆🏾",
+    "emoji_order": 1568
   },
   "massage_tone5": {
     "unicode": "1F486-1F3FF",
@@ -19219,7 +20245,8 @@
       "girl",
       "woman"
     ],
-    "moji": "💆🏿"
+    "moji": "💆🏿",
+    "emoji_order": 1569
   },
   "meat_on_bone": {
     "unicode": "1F356",
@@ -19237,7 +20264,8 @@
       "animal",
       "cooked"
     ],
-    "moji": "🍖"
+    "moji": "🍖",
+    "emoji_order": 374
   },
   "medal": {
     "unicode": "1F3C5",
@@ -19264,7 +20292,8 @@
       "sport",
       "perfect"
     ],
-    "moji": "🏅"
+    "moji": "🏅",
+    "emoji_order": 452
   },
   "mega": {
     "unicode": "1F4E3",
@@ -19281,7 +20310,8 @@
       "object",
       "sport"
     ],
-    "moji": "📣"
+    "moji": "📣",
+    "emoji_order": 999
   },
   "melon": {
     "unicode": "1F348",
@@ -19300,7 +20330,8 @@
       "honeydew",
       "boobs"
     ],
-    "moji": "🍈"
+    "moji": "🍈",
+    "emoji_order": 361
   },
   "menorah": {
     "unicode": "1F54E",
@@ -19317,7 +20348,8 @@
       "symbol",
       "holidays"
     ],
-    "moji": "🕎"
+    "moji": "🕎",
+    "emoji_order": 791
   },
   "mens": {
     "unicode": "1F6B9",
@@ -19339,7 +20371,8 @@
       "avatar",
       "symbol"
     ],
-    "moji": "🚹"
+    "moji": "🚹",
+    "emoji_order": 888
   },
   "metal": {
     "unicode": "1F918",
@@ -19363,7 +20396,8 @@
       "boys night",
       "parties"
     ],
-    "moji": "🤘"
+    "moji": "🤘",
+    "emoji_order": 108
   },
   "metal_tone1": {
     "unicode": "1F918-1F3FB",
@@ -19381,7 +20415,8 @@
       "fingers",
       "rocknroll"
     ],
-    "moji": "🤘🏻"
+    "moji": "🤘🏻",
+    "emoji_order": 1395
   },
   "metal_tone2": {
     "unicode": "1F918-1F3FC",
@@ -19399,7 +20434,8 @@
       "fingers",
       "rocknroll"
     ],
-    "moji": "🤘🏼"
+    "moji": "🤘🏼",
+    "emoji_order": 1396
   },
   "metal_tone3": {
     "unicode": "1F918-1F3FD",
@@ -19417,7 +20453,8 @@
       "fingers",
       "rocknroll"
     ],
-    "moji": "🤘🏽"
+    "moji": "🤘🏽",
+    "emoji_order": 1397
   },
   "metal_tone4": {
     "unicode": "1F918-1F3FE",
@@ -19435,7 +20472,8 @@
       "fingers",
       "rocknroll"
     ],
-    "moji": "🤘🏾"
+    "moji": "🤘🏾",
+    "emoji_order": 1398
   },
   "metal_tone5": {
     "unicode": "1F918-1F3FF",
@@ -19453,7 +20491,8 @@
       "fingers",
       "rocknroll"
     ],
-    "moji": "🤘🏿"
+    "moji": "🤘🏿",
+    "emoji_order": 1399
   },
   "metro": {
     "unicode": "1F687",
@@ -19474,7 +20513,8 @@
       "train",
       "travel"
     ],
-    "moji": "🚇"
+    "moji": "🚇",
+    "emoji_order": 508
   },
   "microphone": {
     "unicode": "1F3A4",
@@ -19495,7 +20535,8 @@
       "karaoke",
       "instruments"
     ],
-    "moji": "🎤"
+    "moji": "🎤",
+    "emoji_order": 461
   },
   "microphone2": {
     "unicode": "1F399",
@@ -19514,7 +20555,8 @@
       "electronics",
       "object"
     ],
-    "moji": "🎙"
+    "moji": "🎙",
+    "emoji_order": 619
   },
   "microscope": {
     "unicode": "1F52C",
@@ -19531,7 +20573,8 @@
       "object",
       "science"
     ],
-    "moji": "🔬"
+    "moji": "🔬",
+    "emoji_order": 669
   },
   "middle_finger": {
     "unicode": "1F595",
@@ -19550,7 +20593,8 @@
       "middle finger",
       "diversity"
     ],
-    "moji": "🖕"
+    "moji": "🖕",
+    "emoji_order": 106
   },
   "middle_finger_tone1": {
     "unicode": "1F595-1F3FB",
@@ -19565,7 +20609,8 @@
     "keywords": [
       "fu"
     ],
-    "moji": "🖕🏻"
+    "moji": "🖕🏻",
+    "emoji_order": 1385
   },
   "middle_finger_tone2": {
     "unicode": "1F595-1F3FC",
@@ -19580,7 +20625,8 @@
     "keywords": [
       "fu"
     ],
-    "moji": "🖕🏼"
+    "moji": "🖕🏼",
+    "emoji_order": 1386
   },
   "middle_finger_tone3": {
     "unicode": "1F595-1F3FD",
@@ -19595,7 +20641,8 @@
     "keywords": [
       "fu"
     ],
-    "moji": "🖕🏽"
+    "moji": "🖕🏽",
+    "emoji_order": 1387
   },
   "middle_finger_tone4": {
     "unicode": "1F595-1F3FE",
@@ -19610,7 +20657,8 @@
     "keywords": [
       "fu"
     ],
-    "moji": "🖕🏾"
+    "moji": "🖕🏾",
+    "emoji_order": 1388
   },
   "middle_finger_tone5": {
     "unicode": "1F595-1F3FF",
@@ -19625,7 +20673,8 @@
     "keywords": [
       "fu"
     ],
-    "moji": "🖕🏿"
+    "moji": "🖕🏿",
+    "emoji_order": 1389
   },
   "military_medal": {
     "unicode": "1F396",
@@ -19645,7 +20694,8 @@
       "award",
       "win"
     ],
-    "moji": "🎖"
+    "moji": "🎖",
+    "emoji_order": 453
   },
   "milk": {
     "unicode": "1F95B",
@@ -19658,7 +20708,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥛"
+    "moji": "🥛",
+    "emoji_order": 10171
   },
   "milky_way": {
     "unicode": "1F30C",
@@ -19681,7 +20732,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🌌"
+    "moji": "🌌",
+    "emoji_order": 561
   },
   "minibus": {
     "unicode": "1F690",
@@ -19699,7 +20751,8 @@
       "city",
       "transport"
     ],
-    "moji": "🚐"
+    "moji": "🚐",
+    "emoji_order": 485
   },
   "minidisc": {
     "unicode": "1F4BD",
@@ -19717,7 +20770,8 @@
       "technology",
       "electronics"
     ],
-    "moji": "💽"
+    "moji": "💽",
+    "emoji_order": 602
   },
   "mobile_phone_off": {
     "unicode": "1F4F4",
@@ -19731,7 +20785,8 @@
       "mute",
       "symbol"
     ],
-    "moji": "📴"
+    "moji": "📴",
+    "emoji_order": 814
   },
   "money_mouth": {
     "unicode": "1F911",
@@ -19750,7 +20805,8 @@
       "emotion",
       "boys night"
     ],
-    "moji": "🤑"
+    "moji": "🤑",
+    "emoji_order": 25
   },
   "money_with_wings": {
     "unicode": "1F4B8",
@@ -19776,7 +20832,8 @@
       "cash",
       "boys night"
     ],
-    "moji": "💸"
+    "moji": "💸",
+    "emoji_order": 636
   },
   "moneybag": {
     "unicode": "1F4B0",
@@ -19794,7 +20851,8 @@
       "award",
       "money"
     ],
-    "moji": "💰"
+    "moji": "💰",
+    "emoji_order": 641
   },
   "monkey": {
     "unicode": "1F412",
@@ -19813,7 +20871,8 @@
       "silly",
       "wildlife"
     ],
-    "moji": "🐒"
+    "moji": "🐒",
+    "emoji_order": 224
   },
   "monkey_face": {
     "unicode": "1F435",
@@ -19827,7 +20886,8 @@
       "animal",
       "nature"
     ],
-    "moji": "🐵"
+    "moji": "🐵",
+    "emoji_order": 220
   },
   "monorail": {
     "unicode": "1F69D",
@@ -19847,7 +20907,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🚝"
+    "moji": "🚝",
+    "emoji_order": 501
   },
   "mortar_board": {
     "unicode": "1F393",
@@ -19874,7 +20935,8 @@
       "office",
       "accessories"
     ],
-    "moji": "🎓"
+    "moji": "🎓",
+    "emoji_order": 194
   },
   "mosque": {
     "unicode": "1F54C",
@@ -19891,7 +20953,8 @@
       "vacation",
       "condolence"
     ],
-    "moji": "🕌"
+    "moji": "🕌",
+    "emoji_order": 587
   },
   "motor_scooter": {
     "unicode": "1F6F5",
@@ -19906,7 +20969,8 @@
     "keywords": [
       "moped"
     ],
-    "moji": "🛵"
+    "moji": "🛵",
+    "emoji_order": 10153
   },
   "motorboat": {
     "unicode": "1F6E5",
@@ -19924,7 +20988,8 @@
       "powerboat",
       "travel"
     ],
-    "moji": "🛥"
+    "moji": "🛥",
+    "emoji_order": 517
   },
   "motorcycle": {
     "unicode": "1F3CD",
@@ -19942,7 +21007,8 @@
       "transportation",
       "travel"
     ],
-    "moji": "🏍"
+    "moji": "🏍",
+    "emoji_order": 489
   },
   "motorway": {
     "unicode": "1F6E3",
@@ -19961,7 +21027,8 @@
       "vacation",
       "camp"
     ],
-    "moji": "🛣"
+    "moji": "🛣",
+    "emoji_order": 549
   },
   "mount_fuji": {
     "unicode": "1F5FB",
@@ -19982,7 +21049,8 @@
       "cold",
       "camp"
     ],
-    "moji": "🗻"
+    "moji": "🗻",
+    "emoji_order": 543
   },
   "mountain": {
     "unicode": "26F0",
@@ -19999,7 +21067,8 @@
       "vacation",
       "camp"
     ],
-    "moji": "⛰"
+    "moji": "⛰",
+    "emoji_order": 541
   },
   "mountain_bicyclist": {
     "unicode": "1F6B5",
@@ -20022,7 +21091,8 @@
       "sport",
       "diversity"
     ],
-    "moji": "🚵"
+    "moji": "🚵",
+    "emoji_order": 447
   },
   "mountain_bicyclist_tone1": {
     "unicode": "1F6B5-1F3FB",
@@ -20039,7 +21109,8 @@
       "pedal",
       "bicycle"
     ],
-    "moji": "🚵🏻"
+    "moji": "🚵🏻",
+    "emoji_order": 1605
   },
   "mountain_bicyclist_tone2": {
     "unicode": "1F6B5-1F3FC",
@@ -20056,7 +21127,8 @@
       "pedal",
       "bicycle"
     ],
-    "moji": "🚵🏼"
+    "moji": "🚵🏼",
+    "emoji_order": 1606
   },
   "mountain_bicyclist_tone3": {
     "unicode": "1F6B5-1F3FD",
@@ -20073,7 +21145,8 @@
       "pedal",
       "bicycle"
     ],
-    "moji": "🚵🏽"
+    "moji": "🚵🏽",
+    "emoji_order": 1607
   },
   "mountain_bicyclist_tone4": {
     "unicode": "1F6B5-1F3FE",
@@ -20090,7 +21163,8 @@
       "pedal",
       "bicycle"
     ],
-    "moji": "🚵🏾"
+    "moji": "🚵🏾",
+    "emoji_order": 1608
   },
   "mountain_bicyclist_tone5": {
     "unicode": "1F6B5-1F3FF",
@@ -20107,7 +21181,8 @@
       "pedal",
       "bicycle"
     ],
-    "moji": "🚵🏿"
+    "moji": "🚵🏿",
+    "emoji_order": 1609
   },
   "mountain_cableway": {
     "unicode": "1F6A0",
@@ -20127,7 +21202,8 @@
       "railway",
       "travel"
     ],
-    "moji": "🚠"
+    "moji": "🚠",
+    "emoji_order": 497
   },
   "mountain_railway": {
     "unicode": "1F69E",
@@ -20146,7 +21222,8 @@
       "transport",
       "travel"
     ],
-    "moji": "🚞"
+    "moji": "🚞",
+    "emoji_order": 505
   },
   "mountain_snow": {
     "unicode": "1F3D4",
@@ -20168,7 +21245,8 @@
       "vacation",
       "camp"
     ],
-    "moji": "🏔"
+    "moji": "🏔",
+    "emoji_order": 542
   },
   "mouse": {
     "unicode": "1F42D",
@@ -20182,7 +21260,8 @@
       "animal",
       "nature"
     ],
-    "moji": "🐭"
+    "moji": "🐭",
+    "emoji_order": 207
   },
   "mouse2": {
     "unicode": "1F401",
@@ -20199,7 +21278,8 @@
       "mice",
       "rodent"
     ],
-    "moji": "🐁"
+    "moji": "🐁",
+    "emoji_order": 266
   },
   "mouse_three_button": {
     "unicode": "1F5B1",
@@ -20220,7 +21300,8 @@
       "work",
       "game"
     ],
-    "moji": "🖱"
+    "moji": "🖱",
+    "emoji_order": 598
   },
   "movie_camera": {
     "unicode": "1F3A5",
@@ -20241,7 +21322,8 @@
       "picture",
       "object"
     ],
-    "moji": "🎥"
+    "moji": "🎥",
+    "emoji_order": 610
   },
   "moyai": {
     "unicode": "1F5FF",
@@ -20257,7 +21339,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🗿"
+    "moji": "🗿",
+    "emoji_order": 689
   },
   "mrs_claus": {
     "unicode": "1F936",
@@ -20270,7 +21353,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤶"
+    "moji": "🤶",
+    "emoji_order": 10112
   },
   "mrs_claus_tone1": {
     "unicode": "1F936-1F3FB",
@@ -20283,7 +21367,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤶🏻"
+    "moji": "🤶🏻",
+    "emoji_order": 10005
   },
   "mrs_claus_tone2": {
     "unicode": "1F936-1F3FC",
@@ -20296,7 +21381,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤶🏼"
+    "moji": "🤶🏼",
+    "emoji_order": 10006
   },
   "mrs_claus_tone3": {
     "unicode": "1F936-1F3FD",
@@ -20309,7 +21395,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤶🏽"
+    "moji": "🤶🏽",
+    "emoji_order": 10007
   },
   "mrs_claus_tone4": {
     "unicode": "1F936-1F3FE",
@@ -20322,7 +21409,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤶🏾"
+    "moji": "🤶🏾",
+    "emoji_order": 10008
   },
   "mrs_claus_tone5": {
     "unicode": "1F936-1F3FF",
@@ -20335,7 +21423,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤶🏿"
+    "moji": "🤶🏿",
+    "emoji_order": 10009
   },
   "muscle": {
     "unicode": "1F4AA",
@@ -20360,7 +21449,8 @@
       "feminist",
       "boys night"
     ],
-    "moji": "💪"
+    "moji": "💪",
+    "emoji_order": 99
   },
   "muscle_tone1": {
     "unicode": "1F4AA-1F3FB",
@@ -20378,7 +21468,8 @@
       "muscle",
       "bicep"
     ],
-    "moji": "💪🏻"
+    "moji": "💪🏻",
+    "emoji_order": 1350
   },
   "muscle_tone2": {
     "unicode": "1F4AA-1F3FC",
@@ -20396,7 +21487,8 @@
       "muscle",
       "bicep"
     ],
-    "moji": "💪🏼"
+    "moji": "💪🏼",
+    "emoji_order": 1351
   },
   "muscle_tone3": {
     "unicode": "1F4AA-1F3FD",
@@ -20414,7 +21506,8 @@
       "muscle",
       "bicep"
     ],
-    "moji": "💪🏽"
+    "moji": "💪🏽",
+    "emoji_order": 1352
   },
   "muscle_tone4": {
     "unicode": "1F4AA-1F3FE",
@@ -20432,7 +21525,8 @@
       "muscle",
       "bicep"
     ],
-    "moji": "💪🏾"
+    "moji": "💪🏾",
+    "emoji_order": 1353
   },
   "muscle_tone5": {
     "unicode": "1F4AA-1F3FF",
@@ -20450,7 +21544,8 @@
       "muscle",
       "bicep"
     ],
-    "moji": "💪🏿"
+    "moji": "💪🏿",
+    "emoji_order": 1354
   },
   "mushroom": {
     "unicode": "1F344",
@@ -20470,7 +21565,8 @@
       "nature",
       "drugs"
     ],
-    "moji": "🍄"
+    "moji": "🍄",
+    "emoji_order": 300
   },
   "musical_keyboard": {
     "unicode": "1F3B9",
@@ -20489,7 +21585,8 @@
       "electric",
       "instruments"
     ],
-    "moji": "🎹"
+    "moji": "🎹",
+    "emoji_order": 464
   },
   "musical_note": {
     "unicode": "1F3B5",
@@ -20508,7 +21605,8 @@
       "instruments",
       "symbol"
     ],
-    "moji": "🎵"
+    "moji": "🎵",
+    "emoji_order": 953
   },
   "musical_score": {
     "unicode": "1F3BC",
@@ -20529,7 +21627,8 @@
       "staff",
       "instruments"
     ],
-    "moji": "🎼"
+    "moji": "🎼",
+    "emoji_order": 463
   },
   "mute": {
     "unicode": "1F507",
@@ -20545,7 +21644,8 @@
       "alarm",
       "symbol"
     ],
-    "moji": "🔇"
+    "moji": "🔇",
+    "emoji_order": 998
   },
   "nail_care": {
     "unicode": "1F485",
@@ -20565,7 +21665,8 @@
       "diversity",
       "girls night"
     ],
-    "moji": "💅"
+    "moji": "💅",
+    "emoji_order": 111
   },
   "nail_care_tone1": {
     "unicode": "1F485-1F3FB",
@@ -20579,7 +21680,8 @@
       "beauty",
       "manicure"
     ],
-    "moji": "💅🏻"
+    "moji": "💅🏻",
+    "emoji_order": 1410
   },
   "nail_care_tone2": {
     "unicode": "1F485-1F3FC",
@@ -20593,7 +21695,8 @@
       "beauty",
       "manicure"
     ],
-    "moji": "💅🏼"
+    "moji": "💅🏼",
+    "emoji_order": 1411
   },
   "nail_care_tone3": {
     "unicode": "1F485-1F3FD",
@@ -20607,7 +21710,8 @@
       "beauty",
       "manicure"
     ],
-    "moji": "💅🏽"
+    "moji": "💅🏽",
+    "emoji_order": 1412
   },
   "nail_care_tone4": {
     "unicode": "1F485-1F3FE",
@@ -20621,7 +21725,8 @@
       "beauty",
       "manicure"
     ],
-    "moji": "💅🏾"
+    "moji": "💅🏾",
+    "emoji_order": 1413
   },
   "nail_care_tone5": {
     "unicode": "1F485-1F3FF",
@@ -20635,7 +21740,8 @@
       "beauty",
       "manicure"
     ],
-    "moji": "💅🏿"
+    "moji": "💅🏿",
+    "emoji_order": 1414
   },
   "name_badge": {
     "unicode": "1F4DB",
@@ -20650,7 +21756,8 @@
       "forbid",
       "work"
     ],
-    "moji": "📛"
+    "moji": "📛",
+    "emoji_order": 838
   },
   "nauseated_face": {
     "unicode": "1F922",
@@ -20663,7 +21770,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤢"
+    "moji": "🤢",
+    "emoji_order": 10105
   },
   "necktie": {
     "unicode": "1F454",
@@ -20680,7 +21788,8 @@
       "shirt",
       "suitup"
     ],
-    "moji": "👔"
+    "moji": "👔",
+    "emoji_order": 179
   },
   "negative_squared_cross_mark": {
     "unicode": "274E",
@@ -20697,7 +21806,8 @@
       "x",
       "symbol"
     ],
-    "moji": "❎"
+    "moji": "❎",
+    "emoji_order": 870
   },
   "nerd": {
     "unicode": "1F913",
@@ -20713,7 +21823,8 @@
       "smiley",
       "glasses"
     ],
-    "moji": "🤓"
+    "moji": "🤓",
+    "emoji_order": 26
   },
   "neutral_face": {
     "unicode": "1F610",
@@ -20735,7 +21846,8 @@
       "shrug",
       "emotion"
     ],
-    "moji": "😐"
+    "moji": "😐",
+    "emoji_order": 31
   },
   "new": {
     "unicode": "1F195",
@@ -20749,7 +21861,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "🆕"
+    "moji": "🆕",
+    "emoji_order": 900
   },
   "new_moon": {
     "unicode": "1F311",
@@ -20769,7 +21882,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌑"
+    "moji": "🌑",
+    "emoji_order": 312
   },
   "new_moon_with_face": {
     "unicode": "1F31A",
@@ -20792,7 +21906,8 @@
       "space",
       "goodnight"
     ],
-    "moji": "🌚"
+    "moji": "🌚",
+    "emoji_order": 316
   },
   "newspaper": {
     "unicode": "1F4F0",
@@ -20808,7 +21923,8 @@
       "office",
       "write"
     ],
-    "moji": "📰"
+    "moji": "📰",
+    "emoji_order": 735
   },
   "newspaper2": {
     "unicode": "1F5DE",
@@ -20826,7 +21942,8 @@
       "office",
       "write"
     ],
-    "moji": "🗞"
+    "moji": "🗞",
+    "emoji_order": 734
   },
   "ng": {
     "unicode": "1F196",
@@ -20842,7 +21959,8 @@
       "symbol",
       "word"
     ],
-    "moji": "🆖"
+    "moji": "🆖",
+    "emoji_order": 896
   },
   "night_with_stars": {
     "unicode": "1F303",
@@ -20865,7 +21983,8 @@
       "vacation",
       "goodnight"
     ],
-    "moji": "🌃"
+    "moji": "🌃",
+    "emoji_order": 559
   },
   "nine": {
     "moji": "9️⃣",
@@ -20885,7 +22004,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 911
   },
   "no_bell": {
     "unicode": "1F515",
@@ -20902,7 +22022,8 @@
       "alarm",
       "symbol"
     ],
-    "moji": "🔕"
+    "moji": "🔕",
+    "emoji_order": 1002
   },
   "no_bicycles": {
     "unicode": "1F6B3",
@@ -20920,7 +22041,8 @@
       "no",
       "symbol"
     ],
-    "moji": "🚳"
+    "moji": "🚳",
+    "emoji_order": 846
   },
   "no_entry": {
     "unicode": "26D4",
@@ -20942,7 +22064,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "⛔"
+    "moji": "⛔",
+    "emoji_order": 837
   },
   "no_entry_sign": {
     "unicode": "1F6AB",
@@ -20963,7 +22086,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "🚫"
+    "moji": "🚫",
+    "emoji_order": 839
   },
   "no_good": {
     "unicode": "1F645",
@@ -20987,7 +22111,8 @@
       "diversity",
       "girls night"
     ],
-    "moji": "🙅"
+    "moji": "🙅",
+    "emoji_order": 148
   },
   "no_good_tone1": {
     "unicode": "1F645-1F3FB",
@@ -21010,7 +22135,8 @@
       "person",
       "prohibited"
     ],
-    "moji": "🙅🏻"
+    "moji": "🙅🏻",
+    "emoji_order": 1535
   },
   "no_good_tone2": {
     "unicode": "1F645-1F3FC",
@@ -21033,7 +22159,8 @@
       "person",
       "prohibited"
     ],
-    "moji": "🙅🏼"
+    "moji": "🙅🏼",
+    "emoji_order": 1536
   },
   "no_good_tone3": {
     "unicode": "1F645-1F3FD",
@@ -21056,7 +22183,8 @@
       "person",
       "prohibited"
     ],
-    "moji": "🙅🏽"
+    "moji": "🙅🏽",
+    "emoji_order": 1537
   },
   "no_good_tone4": {
     "unicode": "1F645-1F3FE",
@@ -21079,7 +22207,8 @@
       "person",
       "prohibited"
     ],
-    "moji": "🙅🏾"
+    "moji": "🙅🏾",
+    "emoji_order": 1538
   },
   "no_good_tone5": {
     "unicode": "1F645-1F3FF",
@@ -21102,7 +22231,8 @@
       "person",
       "prohibited"
     ],
-    "moji": "🙅🏿"
+    "moji": "🙅🏿",
+    "emoji_order": 1539
   },
   "no_mobile_phones": {
     "unicode": "1F4F5",
@@ -21118,7 +22248,8 @@
       "symbol",
       "phone"
     ],
-    "moji": "📵"
+    "moji": "📵",
+    "emoji_order": 849
   },
   "no_mouth": {
     "unicode": "1F636",
@@ -21149,7 +22280,8 @@
       "neutral",
       "emotion"
     ],
-    "moji": "😶"
+    "moji": "😶",
+    "emoji_order": 30
   },
   "no_pedestrians": {
     "unicode": "1F6B7",
@@ -21172,7 +22304,8 @@
       "feet",
       "symbol"
     ],
-    "moji": "🚷"
+    "moji": "🚷",
+    "emoji_order": 844
   },
   "no_smoking": {
     "unicode": "1F6AD",
@@ -21194,7 +22327,8 @@
       "nicotine",
       "symbol"
     ],
-    "moji": "🚭"
+    "moji": "🚭",
+    "emoji_order": 884
   },
   "non-potable_water": {
     "unicode": "1F6B1",
@@ -21217,7 +22351,8 @@
       "h20",
       "symbol"
     ],
-    "moji": "🚱"
+    "moji": "🚱",
+    "emoji_order": 847
   },
   "nose": {
     "unicode": "1F443",
@@ -21233,7 +22368,8 @@
       "body",
       "diversity"
     ],
-    "moji": "👃"
+    "moji": "👃",
+    "emoji_order": 115
   },
   "nose_tone1": {
     "unicode": "1F443-1F3FB",
@@ -21247,7 +22383,8 @@
       "smell",
       "sniff"
     ],
-    "moji": "👃🏻"
+    "moji": "👃🏻",
+    "emoji_order": 1420
   },
   "nose_tone2": {
     "unicode": "1F443-1F3FC",
@@ -21261,7 +22398,8 @@
       "smell",
       "sniff"
     ],
-    "moji": "👃🏼"
+    "moji": "👃🏼",
+    "emoji_order": 1421
   },
   "nose_tone3": {
     "unicode": "1F443-1F3FD",
@@ -21275,7 +22413,8 @@
       "smell",
       "sniff"
     ],
-    "moji": "👃🏽"
+    "moji": "👃🏽",
+    "emoji_order": 1422
   },
   "nose_tone4": {
     "unicode": "1F443-1F3FE",
@@ -21289,7 +22428,8 @@
       "smell",
       "sniff"
     ],
-    "moji": "👃🏾"
+    "moji": "👃🏾",
+    "emoji_order": 1423
   },
   "nose_tone5": {
     "unicode": "1F443-1F3FF",
@@ -21303,7 +22443,8 @@
       "smell",
       "sniff"
     ],
-    "moji": "👃🏿"
+    "moji": "👃🏿",
+    "emoji_order": 1424
   },
   "notebook": {
     "unicode": "1F4D3",
@@ -21322,7 +22463,8 @@
       "office",
       "write"
     ],
-    "moji": "📓"
+    "moji": "📓",
+    "emoji_order": 736
   },
   "notebook_with_decorative_cover": {
     "unicode": "1F4D4",
@@ -21341,7 +22483,8 @@
       "office",
       "write"
     ],
-    "moji": "📔"
+    "moji": "📔",
+    "emoji_order": 741
   },
   "notepad_spiral": {
     "unicode": "1F5D2",
@@ -21359,7 +22502,8 @@
       "office",
       "write"
     ],
-    "moji": "🗒"
+    "moji": "🗒",
+    "emoji_order": 730
   },
   "notes": {
     "unicode": "1F3B6",
@@ -21379,7 +22523,8 @@
       "instruments",
       "symbol"
     ],
-    "moji": "🎶"
+    "moji": "🎶",
+    "emoji_order": 954
   },
   "nut_and_bolt": {
     "unicode": "1F529",
@@ -21396,7 +22541,8 @@
       "tool",
       "nutcase"
     ],
-    "moji": "🔩"
+    "moji": "🔩",
+    "emoji_order": 650
   },
   "o": {
     "unicode": "2B55",
@@ -21413,7 +22559,8 @@
       "round",
       "symbol"
     ],
-    "moji": "⭕"
+    "moji": "⭕",
+    "emoji_order": 841
   },
   "o2": {
     "unicode": "1F17E",
@@ -21429,7 +22576,8 @@
       "red-square",
       "symbol"
     ],
-    "moji": "🅾"
+    "moji": "🅾",
+    "emoji_order": 835
   },
   "ocean": {
     "unicode": "1F30A",
@@ -21452,7 +22600,8 @@
       "tropical",
       "swim"
     ],
-    "moji": "🌊"
+    "moji": "🌊",
+    "emoji_order": 351
   },
   "octagonal_sign": {
     "unicode": "1F6D1",
@@ -21465,7 +22614,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🛑"
+    "moji": "🛑",
+    "emoji_order": 10150
   },
   "octopus": {
     "unicode": "1F419",
@@ -21482,7 +22632,8 @@
       "sea",
       "wildlife"
     ],
-    "moji": "🐙"
+    "moji": "🐙",
+    "emoji_order": 219
   },
   "oden": {
     "unicode": "1F362",
@@ -21500,7 +22651,8 @@
       "casserole",
       "stew"
     ],
-    "moji": "🍢"
+    "moji": "🍢",
+    "emoji_order": 393
   },
   "office": {
     "unicode": "1F3E2",
@@ -21516,7 +22668,8 @@
       "work",
       "places"
     ],
-    "moji": "🏢"
+    "moji": "🏢",
+    "emoji_order": 574
   },
   "oil": {
     "unicode": "1F6E2",
@@ -21532,7 +22685,8 @@
       "petroleum",
       "object"
     ],
-    "moji": "🛢"
+    "moji": "🛢",
+    "emoji_order": 635
   },
   "ok": {
     "unicode": "1F197",
@@ -21549,7 +22703,8 @@
       "yes",
       "symbol"
     ],
-    "moji": "🆗"
+    "moji": "🆗",
+    "emoji_order": 897
   },
   "ok_hand": {
     "unicode": "1F44C",
@@ -21578,7 +22733,8 @@
       "good",
       "beautiful"
     ],
-    "moji": "👌"
+    "moji": "👌",
+    "emoji_order": 96
   },
   "ok_hand_tone1": {
     "unicode": "1F44C-1F3FB",
@@ -21600,7 +22756,8 @@
       "pot",
       "420"
     ],
-    "moji": "👌🏻"
+    "moji": "👌🏻",
+    "emoji_order": 1335
   },
   "ok_hand_tone2": {
     "unicode": "1F44C-1F3FC",
@@ -21622,7 +22779,8 @@
       "pot",
       "420"
     ],
-    "moji": "👌🏼"
+    "moji": "👌🏼",
+    "emoji_order": 1336
   },
   "ok_hand_tone3": {
     "unicode": "1F44C-1F3FD",
@@ -21644,7 +22802,8 @@
       "pot",
       "420"
     ],
-    "moji": "👌🏽"
+    "moji": "👌🏽",
+    "emoji_order": 1337
   },
   "ok_hand_tone4": {
     "unicode": "1F44C-1F3FE",
@@ -21666,7 +22825,8 @@
       "pot",
       "420"
     ],
-    "moji": "👌🏾"
+    "moji": "👌🏾",
+    "emoji_order": 1338
   },
   "ok_hand_tone5": {
     "unicode": "1F44C-1F3FF",
@@ -21688,7 +22848,8 @@
       "pot",
       "420"
     ],
-    "moji": "👌🏿"
+    "moji": "👌🏿",
+    "emoji_order": 1339
   },
   "ok_woman": {
     "unicode": "1F646",
@@ -21716,7 +22877,8 @@
       "people",
       "diversity"
     ],
-    "moji": "🙆"
+    "moji": "🙆",
+    "emoji_order": 149
   },
   "ok_woman_tone1": {
     "unicode": "1F646-1F3FB",
@@ -21736,7 +22898,8 @@
       "okay",
       "accept"
     ],
-    "moji": "🙆🏻"
+    "moji": "🙆🏻",
+    "emoji_order": 1540
   },
   "ok_woman_tone2": {
     "unicode": "1F646-1F3FC",
@@ -21756,7 +22919,8 @@
       "okay",
       "accept"
     ],
-    "moji": "🙆🏼"
+    "moji": "🙆🏼",
+    "emoji_order": 1541
   },
   "ok_woman_tone3": {
     "unicode": "1F646-1F3FD",
@@ -21776,7 +22940,8 @@
       "okay",
       "accept"
     ],
-    "moji": "🙆🏽"
+    "moji": "🙆🏽",
+    "emoji_order": 1542
   },
   "ok_woman_tone4": {
     "unicode": "1F646-1F3FE",
@@ -21796,7 +22961,8 @@
       "okay",
       "accept"
     ],
-    "moji": "🙆🏾"
+    "moji": "🙆🏾",
+    "emoji_order": 1543
   },
   "ok_woman_tone5": {
     "unicode": "1F646-1F3FF",
@@ -21816,7 +22982,8 @@
       "okay",
       "accept"
     ],
-    "moji": "🙆🏿"
+    "moji": "🙆🏿",
+    "emoji_order": 1544
   },
   "older_man": {
     "unicode": "1F474",
@@ -21834,7 +23001,8 @@
       "old people",
       "diversity"
     ],
-    "moji": "👴"
+    "moji": "👴",
+    "emoji_order": 127
   },
   "older_man_tone1": {
     "unicode": "1F474-1F3FB",
@@ -21850,7 +23018,8 @@
       "grandpa",
       "grandfather"
     ],
-    "moji": "👴🏻"
+    "moji": "👴🏻",
+    "emoji_order": 1455
   },
   "older_man_tone2": {
     "unicode": "1F474-1F3FC",
@@ -21866,7 +23035,8 @@
       "grandpa",
       "grandfather"
     ],
-    "moji": "👴🏼"
+    "moji": "👴🏼",
+    "emoji_order": 1456
   },
   "older_man_tone3": {
     "unicode": "1F474-1F3FD",
@@ -21882,7 +23052,8 @@
       "grandpa",
       "grandfather"
     ],
-    "moji": "👴🏽"
+    "moji": "👴🏽",
+    "emoji_order": 1457
   },
   "older_man_tone4": {
     "unicode": "1F474-1F3FE",
@@ -21898,7 +23069,8 @@
       "grandpa",
       "grandfather"
     ],
-    "moji": "👴🏾"
+    "moji": "👴🏾",
+    "emoji_order": 1458
   },
   "older_man_tone5": {
     "unicode": "1F474-1F3FF",
@@ -21914,7 +23086,8 @@
       "grandpa",
       "grandfather"
     ],
-    "moji": "👴🏿"
+    "moji": "👴🏿",
+    "emoji_order": 1459
   },
   "older_woman": {
     "unicode": "1F475",
@@ -21936,7 +23109,8 @@
       "old people",
       "diversity"
     ],
-    "moji": "👵"
+    "moji": "👵",
+    "emoji_order": 128
   },
   "older_woman_tone1": {
     "unicode": "1F475-1F3FB",
@@ -21955,7 +23129,8 @@
       "grandma",
       "grandmother"
     ],
-    "moji": "👵🏻"
+    "moji": "👵🏻",
+    "emoji_order": 1460
   },
   "older_woman_tone2": {
     "unicode": "1F475-1F3FC",
@@ -21974,7 +23149,8 @@
       "grandma",
       "grandmother"
     ],
-    "moji": "👵🏼"
+    "moji": "👵🏼",
+    "emoji_order": 1461
   },
   "older_woman_tone3": {
     "unicode": "1F475-1F3FD",
@@ -21993,7 +23169,8 @@
       "grandma",
       "grandmother"
     ],
-    "moji": "👵🏽"
+    "moji": "👵🏽",
+    "emoji_order": 1462
   },
   "older_woman_tone4": {
     "unicode": "1F475-1F3FE",
@@ -22012,7 +23189,8 @@
       "grandma",
       "grandmother"
     ],
-    "moji": "👵🏾"
+    "moji": "👵🏾",
+    "emoji_order": 1463
   },
   "older_woman_tone5": {
     "unicode": "1F475-1F3FF",
@@ -22031,7 +23209,8 @@
       "grandma",
       "grandmother"
     ],
-    "moji": "👵🏿"
+    "moji": "👵🏿",
+    "emoji_order": 1464
   },
   "om_symbol": {
     "unicode": "1F549",
@@ -22053,7 +23232,8 @@
       "religion",
       "symbol"
     ],
-    "moji": "🕉"
+    "moji": "🕉",
+    "emoji_order": 787
   },
   "on": {
     "unicode": "1F51B",
@@ -22068,7 +23248,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🔛"
+    "moji": "🔛",
+    "emoji_order": 970
   },
   "oncoming_automobile": {
     "unicode": "1F698",
@@ -22086,7 +23267,8 @@
       "automobile",
       "travel"
     ],
-    "moji": "🚘"
+    "moji": "🚘",
+    "emoji_order": 494
   },
   "oncoming_bus": {
     "unicode": "1F68D",
@@ -22105,7 +23287,8 @@
       "public",
       "travel"
     ],
-    "moji": "🚍"
+    "moji": "🚍",
+    "emoji_order": 493
   },
   "oncoming_police_car": {
     "unicode": "1F694",
@@ -22130,7 +23313,8 @@
       "transportation",
       "911"
     ],
-    "moji": "🚔"
+    "moji": "🚔",
+    "emoji_order": 492
   },
   "oncoming_taxi": {
     "unicode": "1F696",
@@ -22153,7 +23337,8 @@
       "transportation",
       "travel"
     ],
-    "moji": "🚖"
+    "moji": "🚖",
+    "emoji_order": 495
   },
   "one": {
     "moji": "1️⃣",
@@ -22173,7 +23358,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 903
   },
   "open_file_folder": {
     "unicode": "1F4C2",
@@ -22189,7 +23375,8 @@
       "work",
       "office"
     ],
-    "moji": "📂"
+    "moji": "📂",
+    "emoji_order": 732
   },
   "open_hands": {
     "unicode": "1F450",
@@ -22207,7 +23394,8 @@
       "diversity",
       "condolence"
     ],
-    "moji": "👐"
+    "moji": "👐",
+    "emoji_order": 98
   },
   "open_hands_tone1": {
     "unicode": "1F450-1F3FB",
@@ -22221,7 +23409,8 @@
       "butterfly",
       "fingers"
     ],
-    "moji": "👐🏻"
+    "moji": "👐🏻",
+    "emoji_order": 1345
   },
   "open_hands_tone2": {
     "unicode": "1F450-1F3FC",
@@ -22235,7 +23424,8 @@
       "butterfly",
       "fingers"
     ],
-    "moji": "👐🏼"
+    "moji": "👐🏼",
+    "emoji_order": 1346
   },
   "open_hands_tone3": {
     "unicode": "1F450-1F3FD",
@@ -22249,7 +23439,8 @@
       "butterfly",
       "fingers"
     ],
-    "moji": "👐🏽"
+    "moji": "👐🏽",
+    "emoji_order": 1347
   },
   "open_hands_tone4": {
     "unicode": "1F450-1F3FE",
@@ -22263,7 +23454,8 @@
       "butterfly",
       "fingers"
     ],
-    "moji": "👐🏾"
+    "moji": "👐🏾",
+    "emoji_order": 1348
   },
   "open_hands_tone5": {
     "unicode": "1F450-1F3FF",
@@ -22277,7 +23469,8 @@
       "butterfly",
       "fingers"
     ],
-    "moji": "👐🏿"
+    "moji": "👐🏿",
+    "emoji_order": 1349
   },
   "open_mouth": {
     "unicode": "1F62E",
@@ -22307,7 +23500,8 @@
       "surprised",
       "emotion"
     ],
-    "moji": "😮"
+    "moji": "😮",
+    "emoji_order": 50
   },
   "ophiuchus": {
     "unicode": "26CE",
@@ -22331,7 +23525,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "⛎"
+    "moji": "⛎",
+    "emoji_order": 795
   },
   "orange_book": {
     "unicode": "1F4D9",
@@ -22350,7 +23545,8 @@
       "write",
       "book"
     ],
-    "moji": "📙"
+    "moji": "📙",
+    "emoji_order": 740
   },
   "orthodox_cross": {
     "unicode": "2626",
@@ -22365,7 +23561,8 @@
       "religion",
       "symbol"
     ],
-    "moji": "☦"
+    "moji": "☦",
+    "emoji_order": 793
   },
   "outbox_tray": {
     "unicode": "1F4E4",
@@ -22381,7 +23578,8 @@
       "work",
       "office"
     ],
-    "moji": "📤"
+    "moji": "📤",
+    "emoji_order": 714
   },
   "owl": {
     "unicode": "1F989",
@@ -22392,7 +23590,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦉"
+    "moji": "🦉",
+    "emoji_order": 10129
   },
   "ox": {
     "unicode": "1F402",
@@ -22407,7 +23606,8 @@
       "beef",
       "cow"
     ],
-    "moji": "🐂"
+    "moji": "🐂",
+    "emoji_order": 255
   },
   "package": {
     "unicode": "1F4E6",
@@ -22423,7 +23623,8 @@
       "object",
       "office"
     ],
-    "moji": "📦"
+    "moji": "📦",
+    "emoji_order": 711
   },
   "page_facing_up": {
     "unicode": "1F4C4",
@@ -22439,7 +23640,8 @@
       "office",
       "write"
     ],
-    "moji": "📄"
+    "moji": "📄",
+    "emoji_order": 721
   },
   "page_with_curl": {
     "unicode": "1F4C3",
@@ -22454,7 +23656,8 @@
       "office",
       "write"
     ],
-    "moji": "📃"
+    "moji": "📃",
+    "emoji_order": 716
   },
   "pager": {
     "unicode": "1F4DF",
@@ -22470,7 +23673,8 @@
       "electronics",
       "work"
     ],
-    "moji": "📟"
+    "moji": "📟",
+    "emoji_order": 615
   },
   "paintbrush": {
     "unicode": "1F58C",
@@ -22490,7 +23694,8 @@
       "office",
       "write"
     ],
-    "moji": "🖌"
+    "moji": "🖌",
+    "emoji_order": 766
   },
   "palm_tree": {
     "unicode": "1F334",
@@ -22512,7 +23717,8 @@
       "tropical",
       "trees"
     ],
-    "moji": "🌴"
+    "moji": "🌴",
+    "emoji_order": 282
   },
   "pancakes": {
     "unicode": "1F95E",
@@ -22523,7 +23729,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥞"
+    "moji": "🥞",
+    "emoji_order": 10174
   },
   "panda_face": {
     "unicode": "1F43C",
@@ -22551,7 +23758,8 @@
       "wildlife",
       "roar"
     ],
-    "moji": "🐼"
+    "moji": "🐼",
+    "emoji_order": 211
   },
   "paperclip": {
     "unicode": "1F4CE",
@@ -22568,7 +23776,8 @@
       "work",
       "office"
     ],
-    "moji": "📎"
+    "moji": "📎",
+    "emoji_order": 746
   },
   "paperclips": {
     "unicode": "1F587",
@@ -22587,7 +23796,8 @@
       "work",
       "office"
     ],
-    "moji": "🖇"
+    "moji": "🖇",
+    "emoji_order": 747
   },
   "park": {
     "unicode": "1F3DE",
@@ -22611,7 +23821,8 @@
       "park",
       "camp"
     ],
-    "moji": "🏞"
+    "moji": "🏞",
+    "emoji_order": 548
   },
   "parking": {
     "unicode": "1F17F",
@@ -22630,7 +23841,8 @@
       "letter",
       "symbol"
     ],
-    "moji": "🅿"
+    "moji": "🅿",
+    "emoji_order": 886
   },
   "part_alternation_mark": {
     "unicode": "303D",
@@ -22655,7 +23867,8 @@
       "japanese",
       "symbol"
     ],
-    "moji": "〽"
+    "moji": "〽",
+    "emoji_order": 861
   },
   "partly_sunny": {
     "unicode": "26C5",
@@ -22675,7 +23888,8 @@
       "sky",
       "sun"
     ],
-    "moji": "⛅"
+    "moji": "⛅",
+    "emoji_order": 329
   },
   "passport_control": {
     "unicode": "1F6C2",
@@ -22696,7 +23910,8 @@
       "identification",
       "symbol"
     ],
-    "moji": "🛂"
+    "moji": "🛂",
+    "emoji_order": 879
   },
   "pause_button": {
     "unicode": "23F8",
@@ -22713,7 +23928,8 @@
       "sound",
       "symbol"
     ],
-    "moji": "⏸"
+    "moji": "⏸",
+    "emoji_order": 915
   },
   "peace": {
     "unicode": "262E",
@@ -22731,7 +23947,8 @@
       "peace",
       "drugs"
     ],
-    "moji": "☮"
+    "moji": "☮",
+    "emoji_order": 784
   },
   "peach": {
     "unicode": "1F351",
@@ -22750,7 +23967,8 @@
       "pit",
       "butt"
     ],
-    "moji": "🍑"
+    "moji": "🍑",
+    "emoji_order": 363
   },
   "peanuts": {
     "unicode": "1F95C",
@@ -22763,7 +23981,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥜"
+    "moji": "🥜",
+    "emoji_order": 10172
   },
   "pear": {
     "unicode": "1F350",
@@ -22780,7 +23999,8 @@
       "shape",
       "food"
     ],
-    "moji": "🍐"
+    "moji": "🍐",
+    "emoji_order": 354
   },
   "pen_ballpoint": {
     "unicode": "1F58A",
@@ -22799,7 +24019,8 @@
       "object",
       "office"
     ],
-    "moji": "🖊"
+    "moji": "🖊",
+    "emoji_order": 760
   },
   "pen_fountain": {
     "unicode": "1F58B",
@@ -22818,7 +24039,8 @@
       "object",
       "office"
     ],
-    "moji": "🖋"
+    "moji": "🖋",
+    "emoji_order": 761
   },
   "pencil": {
     "unicode": "1F4DD",
@@ -22838,7 +24060,8 @@
       "work",
       "office"
     ],
-    "moji": "📝"
+    "moji": "📝",
+    "emoji_order": 763
   },
   "pencil2": {
     "unicode": "270F",
@@ -22857,7 +24080,8 @@
       "object",
       "office"
     ],
-    "moji": "✏"
+    "moji": "✏",
+    "emoji_order": 764
   },
   "penguin": {
     "unicode": "1F427",
@@ -22872,7 +24096,8 @@
       "nature",
       "wildlife"
     ],
-    "moji": "🐧"
+    "moji": "🐧",
+    "emoji_order": 226
   },
   "pensive": {
     "unicode": "1F614",
@@ -22897,7 +24122,8 @@
       "emotion",
       "rip"
     ],
-    "moji": "😔"
+    "moji": "😔",
+    "emoji_order": 41
   },
   "performing_arts": {
     "unicode": "1F3AD",
@@ -22921,7 +24147,8 @@
       "theatre",
       "movie"
     ],
-    "moji": "🎭"
+    "moji": "🎭",
+    "emoji_order": 458
   },
   "persevere": {
     "unicode": "1F623",
@@ -22945,7 +24172,8 @@
       "angry",
       "emotion"
     ],
-    "moji": "😣"
+    "moji": "😣",
+    "emoji_order": 45
   },
   "person_frowning": {
     "unicode": "1F64D",
@@ -22967,7 +24195,8 @@
       "women",
       "diversity"
     ],
-    "moji": "🙍"
+    "moji": "🙍",
+    "emoji_order": 152
   },
   "person_frowning_tone1": {
     "unicode": "1F64D-1F3FB",
@@ -22986,7 +24215,8 @@
       "sad",
       "frown"
     ],
-    "moji": "🙍🏻"
+    "moji": "🙍🏻",
+    "emoji_order": 1555
   },
   "person_frowning_tone2": {
     "unicode": "1F64D-1F3FC",
@@ -23005,7 +24235,8 @@
       "sad",
       "frown"
     ],
-    "moji": "🙍🏼"
+    "moji": "🙍🏼",
+    "emoji_order": 1556
   },
   "person_frowning_tone3": {
     "unicode": "1F64D-1F3FD",
@@ -23024,7 +24255,8 @@
       "sad",
       "frown"
     ],
-    "moji": "🙍🏽"
+    "moji": "🙍🏽",
+    "emoji_order": 1557
   },
   "person_frowning_tone4": {
     "unicode": "1F64D-1F3FE",
@@ -23043,7 +24275,8 @@
       "sad",
       "frown"
     ],
-    "moji": "🙍🏾"
+    "moji": "🙍🏾",
+    "emoji_order": 1558
   },
   "person_frowning_tone5": {
     "unicode": "1F64D-1F3FF",
@@ -23062,7 +24295,8 @@
       "sad",
       "frown"
     ],
-    "moji": "🙍🏿"
+    "moji": "🙍🏿",
+    "emoji_order": 1559
   },
   "person_with_blond_hair": {
     "unicode": "1F471",
@@ -23084,7 +24318,8 @@
       "men",
       "diversity"
     ],
-    "moji": "👱"
+    "moji": "👱",
+    "emoji_order": 126
   },
   "person_with_blond_hair_tone1": {
     "unicode": "1F471-1F3FB",
@@ -23103,7 +24338,8 @@
       "westerner",
       "occidental"
     ],
-    "moji": "👱🏻"
+    "moji": "👱🏻",
+    "emoji_order": 1450
   },
   "person_with_blond_hair_tone2": {
     "unicode": "1F471-1F3FC",
@@ -23122,7 +24358,8 @@
       "westerner",
       "occidental"
     ],
-    "moji": "👱🏼"
+    "moji": "👱🏼",
+    "emoji_order": 1451
   },
   "person_with_blond_hair_tone3": {
     "unicode": "1F471-1F3FD",
@@ -23141,7 +24378,8 @@
       "westerner",
       "occidental"
     ],
-    "moji": "👱🏽"
+    "moji": "👱🏽",
+    "emoji_order": 1452
   },
   "person_with_blond_hair_tone4": {
     "unicode": "1F471-1F3FE",
@@ -23160,7 +24398,8 @@
       "westerner",
       "occidental"
     ],
-    "moji": "👱🏾"
+    "moji": "👱🏾",
+    "emoji_order": 1453
   },
   "person_with_blond_hair_tone5": {
     "unicode": "1F471-1F3FF",
@@ -23179,7 +24418,8 @@
       "westerner",
       "occidental"
     ],
-    "moji": "👱🏿"
+    "moji": "👱🏿",
+    "emoji_order": 1454
   },
   "person_with_pouting_face": {
     "unicode": "1F64E",
@@ -23201,7 +24441,8 @@
       "women",
       "diversity"
     ],
-    "moji": "🙎"
+    "moji": "🙎",
+    "emoji_order": 151
   },
   "person_with_pouting_face_tone1": {
     "unicode": "1F64E-1F3FB",
@@ -23220,7 +24461,8 @@
       "cute",
       "annoyed"
     ],
-    "moji": "🙎🏻"
+    "moji": "🙎🏻",
+    "emoji_order": 1550
   },
   "person_with_pouting_face_tone2": {
     "unicode": "1F64E-1F3FC",
@@ -23239,7 +24481,8 @@
       "cute",
       "annoyed"
     ],
-    "moji": "🙎🏼"
+    "moji": "🙎🏼",
+    "emoji_order": 1551
   },
   "person_with_pouting_face_tone3": {
     "unicode": "1F64E-1F3FD",
@@ -23258,7 +24501,8 @@
       "cute",
       "annoyed"
     ],
-    "moji": "🙎🏽"
+    "moji": "🙎🏽",
+    "emoji_order": 1552
   },
   "person_with_pouting_face_tone4": {
     "unicode": "1F64E-1F3FE",
@@ -23277,7 +24521,8 @@
       "cute",
       "annoyed"
     ],
-    "moji": "🙎🏾"
+    "moji": "🙎🏾",
+    "emoji_order": 1553
   },
   "person_with_pouting_face_tone5": {
     "unicode": "1F64E-1F3FF",
@@ -23296,7 +24541,8 @@
       "cute",
       "annoyed"
     ],
-    "moji": "🙎🏿"
+    "moji": "🙎🏿",
+    "emoji_order": 1554
   },
   "pick": {
     "unicode": "26CF",
@@ -23312,7 +24558,8 @@
       "tool",
       "weapon"
     ],
-    "moji": "⛏"
+    "moji": "⛏",
+    "emoji_order": 649
   },
   "pig": {
     "unicode": "1F437",
@@ -23326,7 +24573,8 @@
       "animal",
       "oink"
     ],
-    "moji": "🐷"
+    "moji": "🐷",
+    "emoji_order": 216
   },
   "pig2": {
     "unicode": "1F416",
@@ -23351,7 +24599,8 @@
       "greed",
       "greedy"
     ],
-    "moji": "🐖"
+    "moji": "🐖",
+    "emoji_order": 264
   },
   "pig_nose": {
     "unicode": "1F43D",
@@ -23374,7 +24623,8 @@
       "smell",
       "truffle"
     ],
-    "moji": "🐽"
+    "moji": "🐽",
+    "emoji_order": 217
   },
   "pill": {
     "unicode": "1F48A",
@@ -23390,7 +24640,8 @@
       "object",
       "drugs"
     ],
-    "moji": "💊"
+    "moji": "💊",
+    "emoji_order": 671
   },
   "pineapple": {
     "unicode": "1F34D",
@@ -23409,7 +24660,8 @@
       "tropical",
       "flower"
     ],
-    "moji": "🍍"
+    "moji": "🍍",
+    "emoji_order": 364
   },
   "ping_pong": {
     "unicode": "1F3D3",
@@ -23427,7 +24679,8 @@
       "sport",
       "ping pong"
     ],
-    "moji": "🏓"
+    "moji": "🏓",
+    "emoji_order": 429
   },
   "pisces": {
     "unicode": "2653",
@@ -23452,7 +24705,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♓"
+    "moji": "♓",
+    "emoji_order": 807
   },
   "pizza": {
     "unicode": "1F355",
@@ -23474,7 +24728,8 @@
       "peperoni",
       "boys night"
     ],
-    "moji": "🍕"
+    "moji": "🍕",
+    "emoji_order": 380
   },
   "place_of_worship": {
     "unicode": "1F6D0",
@@ -23491,7 +24746,8 @@
       "symbol",
       "pray"
     ],
-    "moji": "🛐"
+    "moji": "🛐",
+    "emoji_order": 794
   },
   "play_pause": {
     "unicode": "23EF",
@@ -23509,7 +24765,8 @@
       "sound",
       "symbol"
     ],
-    "moji": "⏯"
+    "moji": "⏯",
+    "emoji_order": 916
   },
   "point_down": {
     "unicode": "1F447",
@@ -23527,7 +24784,8 @@
       "hands",
       "diversity"
     ],
-    "moji": "👇"
+    "moji": "👇",
+    "emoji_order": 103
   },
   "point_down_tone1": {
     "unicode": "1F447-1F3FB",
@@ -23542,7 +24800,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👇🏻"
+    "moji": "👇🏻",
+    "emoji_order": 1370
   },
   "point_down_tone2": {
     "unicode": "1F447-1F3FC",
@@ -23557,7 +24816,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👇🏼"
+    "moji": "👇🏼",
+    "emoji_order": 1371
   },
   "point_down_tone3": {
     "unicode": "1F447-1F3FD",
@@ -23572,7 +24832,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👇🏽"
+    "moji": "👇🏽",
+    "emoji_order": 1372
   },
   "point_down_tone4": {
     "unicode": "1F447-1F3FE",
@@ -23587,7 +24848,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👇🏾"
+    "moji": "👇🏾",
+    "emoji_order": 1373
   },
   "point_down_tone5": {
     "unicode": "1F447-1F3FF",
@@ -23602,7 +24864,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👇🏿"
+    "moji": "👇🏿",
+    "emoji_order": 1374
   },
   "point_left": {
     "unicode": "1F448",
@@ -23621,7 +24884,8 @@
       "hi",
       "diversity"
     ],
-    "moji": "👈"
+    "moji": "👈",
+    "emoji_order": 104
   },
   "point_left_tone1": {
     "unicode": "1F448-1F3FB",
@@ -23636,7 +24900,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👈🏻"
+    "moji": "👈🏻",
+    "emoji_order": 1375
   },
   "point_left_tone2": {
     "unicode": "1F448-1F3FC",
@@ -23651,7 +24916,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👈🏼"
+    "moji": "👈🏼",
+    "emoji_order": 1376
   },
   "point_left_tone3": {
     "unicode": "1F448-1F3FD",
@@ -23666,7 +24932,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👈🏽"
+    "moji": "👈🏽",
+    "emoji_order": 1377
   },
   "point_left_tone4": {
     "unicode": "1F448-1F3FE",
@@ -23681,7 +24948,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👈🏾"
+    "moji": "👈🏾",
+    "emoji_order": 1378
   },
   "point_left_tone5": {
     "unicode": "1F448-1F3FF",
@@ -23696,7 +24964,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👈🏿"
+    "moji": "👈🏿",
+    "emoji_order": 1379
   },
   "point_right": {
     "unicode": "1F449",
@@ -23715,7 +24984,8 @@
       "hi",
       "diversity"
     ],
-    "moji": "👉"
+    "moji": "👉",
+    "emoji_order": 105
   },
   "point_right_tone1": {
     "unicode": "1F449-1F3FB",
@@ -23730,7 +25000,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👉🏻"
+    "moji": "👉🏻",
+    "emoji_order": 1380
   },
   "point_right_tone2": {
     "unicode": "1F449-1F3FC",
@@ -23745,7 +25016,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👉🏼"
+    "moji": "👉🏼",
+    "emoji_order": 1381
   },
   "point_right_tone3": {
     "unicode": "1F449-1F3FD",
@@ -23760,7 +25032,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👉🏽"
+    "moji": "👉🏽",
+    "emoji_order": 1382
   },
   "point_right_tone4": {
     "unicode": "1F449-1F3FE",
@@ -23775,7 +25048,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👉🏾"
+    "moji": "👉🏾",
+    "emoji_order": 1383
   },
   "point_right_tone5": {
     "unicode": "1F449-1F3FF",
@@ -23790,7 +25064,8 @@
       "finger",
       "hand"
     ],
-    "moji": "👉🏿"
+    "moji": "👉🏿",
+    "emoji_order": 1384
   },
   "point_up": {
     "unicode": "261D",
@@ -23811,7 +25086,8 @@
       "emojione",
       "diversity"
     ],
-    "moji": "☝"
+    "moji": "☝",
+    "emoji_order": 101
   },
   "point_up_2": {
     "unicode": "1F446",
@@ -23829,7 +25105,8 @@
       "hands",
       "diversity"
     ],
-    "moji": "👆"
+    "moji": "👆",
+    "emoji_order": 102
   },
   "point_up_2_tone1": {
     "unicode": "1F446-1F3FB",
@@ -23845,7 +25122,8 @@
       "hand",
       "one"
     ],
-    "moji": "👆🏻"
+    "moji": "👆🏻",
+    "emoji_order": 1365
   },
   "point_up_2_tone2": {
     "unicode": "1F446-1F3FC",
@@ -23861,7 +25139,8 @@
       "hand",
       "one"
     ],
-    "moji": "👆🏼"
+    "moji": "👆🏼",
+    "emoji_order": 1366
   },
   "point_up_2_tone3": {
     "unicode": "1F446-1F3FD",
@@ -23877,7 +25156,8 @@
       "hand",
       "one"
     ],
-    "moji": "👆🏽"
+    "moji": "👆🏽",
+    "emoji_order": 1367
   },
   "point_up_2_tone4": {
     "unicode": "1F446-1F3FE",
@@ -23893,7 +25173,8 @@
       "hand",
       "one"
     ],
-    "moji": "👆🏾"
+    "moji": "👆🏾",
+    "emoji_order": 1368
   },
   "point_up_2_tone5": {
     "unicode": "1F446-1F3FF",
@@ -23909,7 +25190,8 @@
       "hand",
       "one"
     ],
-    "moji": "👆🏿"
+    "moji": "👆🏿",
+    "emoji_order": 1369
   },
   "point_up_tone1": {
     "unicode": "261D-1F3FB",
@@ -23925,7 +25207,8 @@
       "hand",
       "one"
     ],
-    "moji": "☝🏻"
+    "moji": "☝🏻",
+    "emoji_order": 1360
   },
   "point_up_tone2": {
     "unicode": "261D-1F3FC",
@@ -23941,7 +25224,8 @@
       "hand",
       "one"
     ],
-    "moji": "☝🏼"
+    "moji": "☝🏼",
+    "emoji_order": 1361
   },
   "point_up_tone3": {
     "unicode": "261D-1F3FD",
@@ -23957,7 +25241,8 @@
       "hand",
       "one"
     ],
-    "moji": "☝🏽"
+    "moji": "☝🏽",
+    "emoji_order": 1362
   },
   "point_up_tone4": {
     "unicode": "261D-1F3FE",
@@ -23973,7 +25258,8 @@
       "hand",
       "one"
     ],
-    "moji": "☝🏾"
+    "moji": "☝🏾",
+    "emoji_order": 1363
   },
   "point_up_tone5": {
     "unicode": "261D-1F3FF",
@@ -23989,7 +25275,8 @@
       "hand",
       "one"
     ],
-    "moji": "☝🏿"
+    "moji": "☝🏿",
+    "emoji_order": 1364
   },
   "police_car": {
     "unicode": "1F693",
@@ -24015,7 +25302,8 @@
       "officer",
       "911"
     ],
-    "moji": "🚓"
+    "moji": "🚓",
+    "emoji_order": 482
   },
   "poodle": {
     "unicode": "1F429",
@@ -24036,7 +25324,8 @@
       "sophisticated",
       "vain"
     ],
-    "moji": "🐩"
+    "moji": "🐩",
+    "emoji_order": 271
   },
   "poop": {
     "unicode": "1F4A9",
@@ -24060,7 +25349,8 @@
       "sol",
       "diarrhea"
     ],
-    "moji": "💩"
+    "moji": "💩",
+    "emoji_order": 70
   },
   "popcorn": {
     "unicode": "1F37F",
@@ -24074,7 +25364,8 @@
       "food",
       "parties"
     ],
-    "moji": "🍿"
+    "moji": "🍿",
+    "emoji_order": 404
   },
   "post_office": {
     "unicode": "1F3E3",
@@ -24091,7 +25382,8 @@
       "places",
       "post office"
     ],
-    "moji": "🏣"
+    "moji": "🏣",
+    "emoji_order": 576
   },
   "postal_horn": {
     "unicode": "1F4EF",
@@ -24106,7 +25398,8 @@
       "music",
       "object"
     ],
-    "moji": "📯"
+    "moji": "📯",
+    "emoji_order": 712
   },
   "postbox": {
     "unicode": "1F4EE",
@@ -24122,7 +25415,8 @@
       "letter",
       "object"
     ],
-    "moji": "📮"
+    "moji": "📮",
+    "emoji_order": 706
   },
   "potable_water": {
     "unicode": "1F6B0",
@@ -24148,7 +25442,8 @@
       "h20",
       "symbol"
     ],
-    "moji": "🚰"
+    "moji": "🚰",
+    "emoji_order": 887
   },
   "potato": {
     "unicode": "1F954",
@@ -24159,7 +25454,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥔"
+    "moji": "🥔",
+    "emoji_order": 10141
   },
   "pouch": {
     "unicode": "1F45D",
@@ -24180,7 +25476,8 @@
       "women",
       "fashion"
     ],
-    "moji": "👝"
+    "moji": "👝",
+    "emoji_order": 197
   },
   "poultry_leg": {
     "unicode": "1F357",
@@ -24199,7 +25496,8 @@
       "fried",
       "holidays"
     ],
-    "moji": "🍗"
+    "moji": "🍗",
+    "emoji_order": 373
   },
   "pound": {
     "unicode": "1F4B7",
@@ -24223,7 +25521,8 @@
       "paper",
       "cash"
     ],
-    "moji": "💷"
+    "moji": "💷",
+    "emoji_order": 640
   },
   "pouting_cat": {
     "unicode": "1F63E",
@@ -24243,7 +25542,8 @@
       "frown",
       "cat"
     ],
-    "moji": "😾"
+    "moji": "😾",
+    "emoji_order": 87
   },
   "pray": {
     "unicode": "1F64F",
@@ -24272,7 +25572,8 @@
       "diversity",
       "scientology"
     ],
-    "moji": "🙏"
+    "moji": "🙏",
+    "emoji_order": 100
   },
   "pray_tone1": {
     "unicode": "1F64F-1F3FB",
@@ -24294,7 +25595,8 @@
       "regret",
       "sorry"
     ],
-    "moji": "🙏🏻"
+    "moji": "🙏🏻",
+    "emoji_order": 1355
   },
   "pray_tone2": {
     "unicode": "1F64F-1F3FC",
@@ -24316,7 +25618,8 @@
       "regret",
       "sorry"
     ],
-    "moji": "🙏🏼"
+    "moji": "🙏🏼",
+    "emoji_order": 1356
   },
   "pray_tone3": {
     "unicode": "1F64F-1F3FD",
@@ -24338,7 +25641,8 @@
       "regret",
       "sorry"
     ],
-    "moji": "🙏🏽"
+    "moji": "🙏🏽",
+    "emoji_order": 1357
   },
   "pray_tone4": {
     "unicode": "1F64F-1F3FE",
@@ -24360,7 +25664,8 @@
       "regret",
       "sorry"
     ],
-    "moji": "🙏🏾"
+    "moji": "🙏🏾",
+    "emoji_order": 1358
   },
   "pray_tone5": {
     "unicode": "1F64F-1F3FF",
@@ -24382,7 +25687,8 @@
       "regret",
       "sorry"
     ],
-    "moji": "🙏🏿"
+    "moji": "🙏🏿",
+    "emoji_order": 1359
   },
   "prayer_beads": {
     "unicode": "1F4FF",
@@ -24396,7 +25702,8 @@
       "object",
       "rosary"
     ],
-    "moji": "📿"
+    "moji": "📿",
+    "emoji_order": 665
   },
   "pregnant_woman": {
     "unicode": "1F930",
@@ -24409,7 +25716,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤰"
+    "moji": "🤰",
+    "emoji_order": 10115
   },
   "pregnant_woman_tone1": {
     "unicode": "1F930-1F3FB",
@@ -24422,7 +25730,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤰🏻"
+    "moji": "🤰🏻",
+    "emoji_order": 10025
   },
   "pregnant_woman_tone2": {
     "unicode": "1F930-1F3FC",
@@ -24435,7 +25744,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤰🏼"
+    "moji": "🤰🏼",
+    "emoji_order": 10026
   },
   "pregnant_woman_tone3": {
     "unicode": "1F930-1F3FD",
@@ -24448,7 +25758,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤰🏽"
+    "moji": "🤰🏽",
+    "emoji_order": 10027
   },
   "pregnant_woman_tone4": {
     "unicode": "1F930-1F3FE",
@@ -24461,7 +25772,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤰🏾"
+    "moji": "🤰🏾",
+    "emoji_order": 10028
   },
   "pregnant_woman_tone5": {
     "unicode": "1F930-1F3FF",
@@ -24474,7 +25786,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤰🏿"
+    "moji": "🤰🏿",
+    "emoji_order": 10029
   },
   "prince": {
     "unicode": "1F934",
@@ -24485,7 +25798,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤴"
+    "moji": "🤴",
+    "emoji_order": 10110
   },
   "prince_tone1": {
     "unicode": "1F934-1F3FB",
@@ -24496,7 +25810,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤴🏻"
+    "moji": "🤴🏻",
+    "emoji_order": 10000
   },
   "prince_tone2": {
     "unicode": "1F934-1F3FC",
@@ -24507,7 +25822,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤴🏼"
+    "moji": "🤴🏼",
+    "emoji_order": 10001
   },
   "prince_tone3": {
     "unicode": "1F934-1F3FD",
@@ -24518,7 +25834,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤴🏽"
+    "moji": "🤴🏽",
+    "emoji_order": 10002
   },
   "prince_tone4": {
     "unicode": "1F934-1F3FE",
@@ -24529,7 +25846,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤴🏾"
+    "moji": "🤴🏾",
+    "emoji_order": 10003
   },
   "prince_tone5": {
     "unicode": "1F934-1F3FF",
@@ -24540,7 +25858,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤴🏿"
+    "moji": "🤴🏿",
+    "emoji_order": 10004
   },
   "princess": {
     "unicode": "1F478",
@@ -24570,7 +25889,8 @@
       "beautiful",
       "girls night"
     ],
-    "moji": "👸"
+    "moji": "👸",
+    "emoji_order": 137
   },
   "princess_tone1": {
     "unicode": "1F478-1F3FB",
@@ -24594,7 +25914,8 @@
       "disney",
       "high-maintenance"
     ],
-    "moji": "👸🏻"
+    "moji": "👸🏻",
+    "emoji_order": 1500
   },
   "princess_tone2": {
     "unicode": "1F478-1F3FC",
@@ -24618,7 +25939,8 @@
       "disney",
       "high-maintenance"
     ],
-    "moji": "👸🏼"
+    "moji": "👸🏼",
+    "emoji_order": 1501
   },
   "princess_tone3": {
     "unicode": "1F478-1F3FD",
@@ -24642,7 +25964,8 @@
       "disney",
       "high-maintenance"
     ],
-    "moji": "👸🏽"
+    "moji": "👸🏽",
+    "emoji_order": 1502
   },
   "princess_tone4": {
     "unicode": "1F478-1F3FE",
@@ -24666,7 +25989,8 @@
       "disney",
       "high-maintenance"
     ],
-    "moji": "👸🏾"
+    "moji": "👸🏾",
+    "emoji_order": 1503
   },
   "princess_tone5": {
     "unicode": "1F478-1F3FF",
@@ -24690,7 +26014,8 @@
       "disney",
       "high-maintenance"
     ],
-    "moji": "👸🏿"
+    "moji": "👸🏿",
+    "emoji_order": 1504
   },
   "printer": {
     "unicode": "1F5A8",
@@ -24709,7 +26034,8 @@
       "work",
       "office"
     ],
-    "moji": "🖨"
+    "moji": "🖨",
+    "emoji_order": 597
   },
   "projector": {
     "unicode": "1F4FD",
@@ -24731,7 +26057,8 @@
       "object",
       "camera"
     ],
-    "moji": "📽"
+    "moji": "📽",
+    "emoji_order": 611
   },
   "punch": {
     "unicode": "1F44A",
@@ -24751,7 +26078,8 @@
       "diversity",
       "boys night"
     ],
-    "moji": "👊"
+    "moji": "👊",
+    "emoji_order": 93
   },
   "punch_tone1": {
     "unicode": "1F44A-1F3FB",
@@ -24765,7 +26093,8 @@
       "fist",
       "punch"
     ],
-    "moji": "👊🏻"
+    "moji": "👊🏻",
+    "emoji_order": 1320
   },
   "punch_tone2": {
     "unicode": "1F44A-1F3FC",
@@ -24779,7 +26108,8 @@
       "fist",
       "punch"
     ],
-    "moji": "👊🏼"
+    "moji": "👊🏼",
+    "emoji_order": 1321
   },
   "punch_tone3": {
     "unicode": "1F44A-1F3FD",
@@ -24793,7 +26123,8 @@
       "fist",
       "punch"
     ],
-    "moji": "👊🏽"
+    "moji": "👊🏽",
+    "emoji_order": 1322
   },
   "punch_tone4": {
     "unicode": "1F44A-1F3FE",
@@ -24807,7 +26138,8 @@
       "fist",
       "punch"
     ],
-    "moji": "👊🏾"
+    "moji": "👊🏾",
+    "emoji_order": 1323
   },
   "punch_tone5": {
     "unicode": "1F44A-1F3FF",
@@ -24821,7 +26153,8 @@
       "fist",
       "punch"
     ],
-    "moji": "👊🏿"
+    "moji": "👊🏿",
+    "emoji_order": 1324
   },
   "purple_heart": {
     "unicode": "1F49C",
@@ -24850,7 +26183,8 @@
       "sacrifice",
       "symbol"
     ],
-    "moji": "💜"
+    "moji": "💜",
+    "emoji_order": 773
   },
   "purse": {
     "unicode": "1F45B",
@@ -24874,7 +26208,8 @@
       "shopping",
       "women"
     ],
-    "moji": "👛"
+    "moji": "👛",
+    "emoji_order": 198
   },
   "pushpin": {
     "unicode": "1F4CC",
@@ -24889,7 +26224,8 @@
       "object",
       "office"
     ],
-    "moji": "📌"
+    "moji": "📌",
+    "emoji_order": 751
   },
   "put_litter_in_its_place": {
     "unicode": "1F6AE",
@@ -24909,7 +26245,8 @@
       "can",
       "symbol"
     ],
-    "moji": "🚮"
+    "moji": "🚮",
+    "emoji_order": 892
   },
   "question": {
     "unicode": "2753",
@@ -24926,7 +26263,8 @@
       "punctuation",
       "wth"
     ],
-    "moji": "❓"
+    "moji": "❓",
+    "emoji_order": 852
   },
   "rabbit": {
     "unicode": "1F430",
@@ -24941,7 +26279,8 @@
       "nature",
       "wildlife"
     ],
-    "moji": "🐰"
+    "moji": "🐰",
+    "emoji_order": 209
   },
   "rabbit2": {
     "unicode": "1F407",
@@ -24961,7 +26300,8 @@
       "prolific",
       "wildlife"
     ],
-    "moji": "🐇"
+    "moji": "🐇",
+    "emoji_order": 273
   },
   "race_car": {
     "unicode": "1F3CE",
@@ -24983,7 +26323,8 @@
       "transportation",
       "car"
     ],
-    "moji": "🏎"
+    "moji": "🏎",
+    "emoji_order": 481
   },
   "racehorse": {
     "unicode": "1F40E",
@@ -25017,7 +26358,8 @@
       "pony",
       "wildlife"
     ],
-    "moji": "🐎"
+    "moji": "🐎",
+    "emoji_order": 263
   },
   "radio": {
     "unicode": "1F4FB",
@@ -25034,7 +26376,8 @@
       "program",
       "electronics"
     ],
-    "moji": "📻"
+    "moji": "📻",
+    "emoji_order": 618
   },
   "radio_button": {
     "unicode": "1F518",
@@ -25049,7 +26392,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "🔘"
+    "moji": "🔘",
+    "emoji_order": 974
   },
   "radioactive": {
     "unicode": "2622",
@@ -25065,7 +26409,8 @@
       "symbol",
       "science"
     ],
-    "moji": "☢"
+    "moji": "☢",
+    "emoji_order": 812
   },
   "rage": {
     "unicode": "1F621",
@@ -25087,7 +26432,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😡"
+    "moji": "😡",
+    "emoji_order": 40
   },
   "railway_car": {
     "unicode": "1F683",
@@ -25107,7 +26453,8 @@
       "train",
       "travel"
     ],
-    "moji": "🚃"
+    "moji": "🚃",
+    "emoji_order": 499
   },
   "railway_track": {
     "unicode": "1F6E4",
@@ -25128,7 +26475,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🛤"
+    "moji": "🛤",
+    "emoji_order": 550
   },
   "rainbow": {
     "unicode": "1F308",
@@ -25156,7 +26504,8 @@
       "gay",
       "rain"
     ],
-    "moji": "🌈"
+    "moji": "🌈",
+    "emoji_order": 565
   },
   "raised_back_of_hand": {
     "unicode": "1F91A",
@@ -25169,7 +26518,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤚"
+    "moji": "🤚",
+    "emoji_order": 10119
   },
   "raised_back_of_hand_tone1": {
     "unicode": "1F91A-1F3FB",
@@ -25182,7 +26532,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤚🏻"
+    "moji": "🤚🏻",
+    "emoji_order": 10060
   },
   "raised_back_of_hand_tone2": {
     "unicode": "1F91A-1F3FC",
@@ -25195,7 +26546,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤚🏼"
+    "moji": "🤚🏼",
+    "emoji_order": 10061
   },
   "raised_back_of_hand_tone3": {
     "unicode": "1F91A-1F3FD",
@@ -25208,7 +26560,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤚🏽"
+    "moji": "🤚🏽",
+    "emoji_order": 10062
   },
   "raised_back_of_hand_tone4": {
     "unicode": "1F91A-1F3FE",
@@ -25221,7 +26574,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤚🏾"
+    "moji": "🤚🏾",
+    "emoji_order": 10063
   },
   "raised_back_of_hand_tone5": {
     "unicode": "1F91A-1F3FF",
@@ -25234,7 +26588,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤚🏿"
+    "moji": "🤚🏿",
+    "emoji_order": 10064
   },
   "raised_hand": {
     "unicode": "270B",
@@ -25254,7 +26609,8 @@
       "diversity",
       "girls night"
     ],
-    "moji": "✋"
+    "moji": "✋",
+    "emoji_order": 97
   },
   "raised_hand_tone1": {
     "unicode": "270B-1F3FB",
@@ -25269,7 +26625,8 @@
       "girl",
       "woman"
     ],
-    "moji": "✋🏻"
+    "moji": "✋🏻",
+    "emoji_order": 1340
   },
   "raised_hand_tone2": {
     "unicode": "270B-1F3FC",
@@ -25284,7 +26641,8 @@
       "girl",
       "woman"
     ],
-    "moji": "✋🏼"
+    "moji": "✋🏼",
+    "emoji_order": 1341
   },
   "raised_hand_tone3": {
     "unicode": "270B-1F3FD",
@@ -25299,7 +26657,8 @@
       "girl",
       "woman"
     ],
-    "moji": "✋🏽"
+    "moji": "✋🏽",
+    "emoji_order": 1342
   },
   "raised_hand_tone4": {
     "unicode": "270B-1F3FE",
@@ -25314,7 +26673,8 @@
       "girl",
       "woman"
     ],
-    "moji": "✋🏾"
+    "moji": "✋🏾",
+    "emoji_order": 1343
   },
   "raised_hand_tone5": {
     "unicode": "270B-1F3FF",
@@ -25329,7 +26689,8 @@
       "girl",
       "woman"
     ],
-    "moji": "✋🏿"
+    "moji": "✋🏿",
+    "emoji_order": 1344
   },
   "raised_hands": {
     "unicode": "1F64C",
@@ -25353,7 +26714,8 @@
       "good",
       "parties"
     ],
-    "moji": "🙌"
+    "moji": "🙌",
+    "emoji_order": 88
   },
   "raised_hands_tone1": {
     "unicode": "1F64C-1F3FB",
@@ -25372,7 +26734,8 @@
       "banzai",
       "raised"
     ],
-    "moji": "🙌🏻"
+    "moji": "🙌🏻",
+    "emoji_order": 1295
   },
   "raised_hands_tone2": {
     "unicode": "1F64C-1F3FC",
@@ -25391,7 +26754,8 @@
       "banzai",
       "raised"
     ],
-    "moji": "🙌🏼"
+    "moji": "🙌🏼",
+    "emoji_order": 1296
   },
   "raised_hands_tone3": {
     "unicode": "1F64C-1F3FD",
@@ -25410,7 +26774,8 @@
       "banzai",
       "raised"
     ],
-    "moji": "🙌🏽"
+    "moji": "🙌🏽",
+    "emoji_order": 1297
   },
   "raised_hands_tone4": {
     "unicode": "1F64C-1F3FE",
@@ -25429,7 +26794,8 @@
       "banzai",
       "raised"
     ],
-    "moji": "🙌🏾"
+    "moji": "🙌🏾",
+    "emoji_order": 1298
   },
   "raised_hands_tone5": {
     "unicode": "1F64C-1F3FF",
@@ -25448,7 +26814,8 @@
       "banzai",
       "raised"
     ],
-    "moji": "🙌🏿"
+    "moji": "🙌🏿",
+    "emoji_order": 1299
   },
   "raising_hand": {
     "unicode": "1F64B",
@@ -25471,7 +26838,8 @@
       "women",
       "diversity"
     ],
-    "moji": "🙋"
+    "moji": "🙋",
+    "emoji_order": 150
   },
   "raising_hand_tone1": {
     "unicode": "1F64B-1F3FB",
@@ -25490,7 +26858,8 @@
       "attention",
       "answer"
     ],
-    "moji": "🙋🏻"
+    "moji": "🙋🏻",
+    "emoji_order": 1545
   },
   "raising_hand_tone2": {
     "unicode": "1F64B-1F3FC",
@@ -25509,7 +26878,8 @@
       "attention",
       "answer"
     ],
-    "moji": "🙋🏼"
+    "moji": "🙋🏼",
+    "emoji_order": 1546
   },
   "raising_hand_tone3": {
     "unicode": "1F64B-1F3FD",
@@ -25528,7 +26898,8 @@
       "attention",
       "answer"
     ],
-    "moji": "🙋🏽"
+    "moji": "🙋🏽",
+    "emoji_order": 1547
   },
   "raising_hand_tone4": {
     "unicode": "1F64B-1F3FE",
@@ -25547,7 +26918,8 @@
       "attention",
       "answer"
     ],
-    "moji": "🙋🏾"
+    "moji": "🙋🏾",
+    "emoji_order": 1548
   },
   "raising_hand_tone5": {
     "unicode": "1F64B-1F3FF",
@@ -25566,7 +26938,8 @@
       "attention",
       "answer"
     ],
-    "moji": "🙋🏿"
+    "moji": "🙋🏿",
+    "emoji_order": 1549
   },
   "ram": {
     "unicode": "1F40F",
@@ -25586,7 +26959,8 @@
       "horns",
       "wildlife"
     ],
-    "moji": "🐏"
+    "moji": "🐏",
+    "emoji_order": 261
   },
   "ramen": {
     "unicode": "1F35C",
@@ -25608,7 +26982,8 @@
       "soup",
       "japan"
     ],
-    "moji": "🍜"
+    "moji": "🍜",
+    "emoji_order": 384
   },
   "rat": {
     "unicode": "1F400",
@@ -25626,7 +27001,8 @@
       "crooked",
       "snitch"
     ],
-    "moji": "🐀"
+    "moji": "🐀",
+    "emoji_order": 265
   },
   "record_button": {
     "unicode": "23FA",
@@ -25641,7 +27017,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "⏺"
+    "moji": "⏺",
+    "emoji_order": 918
   },
   "recycle": {
     "unicode": "267B",
@@ -25660,7 +27037,8 @@
       "trash",
       "symbol"
     ],
-    "moji": "♻"
+    "moji": "♻",
+    "emoji_order": 865
   },
   "red_car": {
     "unicode": "1F697",
@@ -25676,7 +27054,8 @@
       "car",
       "travel"
     ],
-    "moji": "🚗"
+    "moji": "🚗",
+    "emoji_order": 476
   },
   "red_circle": {
     "unicode": "1F534",
@@ -25692,7 +27071,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "🔴"
+    "moji": "🔴",
+    "emoji_order": 977
   },
   "registered": {
     "moji": "®",
@@ -25707,7 +27087,8 @@
       "alphabet",
       "circle",
       "symbol"
-    ]
+    ],
+    "emoji_order": 966
   },
   "relaxed": {
     "unicode": "263A",
@@ -25728,7 +27109,8 @@
       "happy",
       "smiley"
     ],
-    "moji": "☺"
+    "moji": "☺",
+    "emoji_order": 14
   },
   "relieved": {
     "unicode": "1F60C",
@@ -25750,7 +27132,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😌"
+    "moji": "😌",
+    "emoji_order": 16
   },
   "reminder_ribbon": {
     "unicode": "1F397",
@@ -25764,7 +27147,8 @@
       "awareness",
       "award"
     ],
-    "moji": "🎗"
+    "moji": "🎗",
+    "emoji_order": 454
   },
   "repeat": {
     "unicode": "1F501",
@@ -25780,7 +27164,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "🔁"
+    "moji": "🔁",
+    "emoji_order": 924
   },
   "repeat_one": {
     "unicode": "1F502",
@@ -25796,7 +27181,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "🔂"
+    "moji": "🔂",
+    "emoji_order": 925
   },
   "restroom": {
     "unicode": "1F6BB",
@@ -25818,7 +27204,8 @@
       "toilet",
       "symbol"
     ],
-    "moji": "🚻"
+    "moji": "🚻",
+    "emoji_order": 891
   },
   "revolving_hearts": {
     "unicode": "1F49E",
@@ -25842,7 +27229,8 @@
       "lovers",
       "symbol"
     ],
-    "moji": "💞"
+    "moji": "💞",
+    "emoji_order": 777
   },
   "rewind": {
     "unicode": "23EA",
@@ -25858,7 +27246,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "⏪"
+    "moji": "⏪",
+    "emoji_order": 922
   },
   "rhino": {
     "unicode": "1F98F",
@@ -25871,7 +27260,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦏"
+    "moji": "🦏",
+    "emoji_order": 10135
   },
   "ribbon": {
     "unicode": "1F380",
@@ -25894,7 +27284,8 @@
       "gift",
       "birthday"
     ],
-    "moji": "🎀"
+    "moji": "🎀",
+    "emoji_order": 693
   },
   "rice": {
     "unicode": "1F35A",
@@ -25913,7 +27304,8 @@
       "sushi",
       "japan"
     ],
-    "moji": "🍚"
+    "moji": "🍚",
+    "emoji_order": 391
   },
   "rice_ball": {
     "unicode": "1F359",
@@ -25934,7 +27326,8 @@
       "sushi",
       "japan"
     ],
-    "moji": "🍙"
+    "moji": "🍙",
+    "emoji_order": 390
   },
   "rice_cracker": {
     "unicode": "1F358",
@@ -25952,7 +27345,8 @@
       "seaweed",
       "sushi"
     ],
-    "moji": "🍘"
+    "moji": "🍘",
+    "emoji_order": 392
   },
   "rice_scene": {
     "unicode": "1F391",
@@ -25978,7 +27372,8 @@
       "sky",
       "travel"
     ],
-    "moji": "🎑"
+    "moji": "🎑",
+    "emoji_order": 540
   },
   "right_facing_fist": {
     "unicode": "1F91C",
@@ -25991,7 +27386,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤜"
+    "moji": "🤜",
+    "emoji_order": 10121
   },
   "right_facing_fist_tone1": {
     "unicode": "1F91C-1F3FB",
@@ -26004,7 +27400,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤜🏻"
+    "moji": "🤜🏻",
+    "emoji_order": 10055
   },
   "right_facing_fist_tone2": {
     "unicode": "1F91C-1F3FC",
@@ -26017,7 +27414,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤜🏼"
+    "moji": "🤜🏼",
+    "emoji_order": 10056
   },
   "right_facing_fist_tone3": {
     "unicode": "1F91C-1F3FD",
@@ -26030,7 +27428,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤜🏽"
+    "moji": "🤜🏽",
+    "emoji_order": 10057
   },
   "right_facing_fist_tone4": {
     "unicode": "1F91C-1F3FE",
@@ -26043,7 +27442,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤜🏾"
+    "moji": "🤜🏾",
+    "emoji_order": 10058
   },
   "right_facing_fist_tone5": {
     "unicode": "1F91C-1F3FF",
@@ -26056,7 +27456,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤜🏿"
+    "moji": "🤜🏿",
+    "emoji_order": 10059
   },
   "ring": {
     "unicode": "1F48D",
@@ -26076,7 +27477,8 @@
       "gem",
       "accessories"
     ],
-    "moji": "💍"
+    "moji": "💍",
+    "emoji_order": 203
   },
   "robot": {
     "unicode": "1F916",
@@ -26092,7 +27494,8 @@
       "monster",
       "robot"
     ],
-    "moji": "🤖"
+    "moji": "🤖",
+    "emoji_order": 78
   },
   "rocket": {
     "unicode": "1F680",
@@ -26116,7 +27519,8 @@
       "fly",
       "blast"
     ],
-    "moji": "🚀"
+    "moji": "🚀",
+    "emoji_order": 521
   },
   "rofl": {
     "unicode": "1F923",
@@ -26129,7 +27533,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤣"
+    "moji": "🤣",
+    "emoji_order": 10106
   },
   "roller_coaster": {
     "unicode": "1F3A2",
@@ -26156,7 +27561,8 @@
       "vacation",
       "roller coaster"
     ],
-    "moji": "🎢"
+    "moji": "🎢",
+    "emoji_order": 533
   },
   "rolling_eyes": {
     "unicode": "1F644",
@@ -26175,7 +27581,8 @@
       "emotion",
       "sarcastic"
     ],
-    "moji": "🙄"
+    "moji": "🙄",
+    "emoji_order": 34
   },
   "rooster": {
     "unicode": "1F413",
@@ -26196,7 +27603,8 @@
       "cock-a-doodle-doo",
       "crowing"
     ],
-    "moji": "🐓"
+    "moji": "🐓",
+    "emoji_order": 267
   },
   "rose": {
     "unicode": "1F339",
@@ -26222,7 +27630,8 @@
       "condolence",
       "beautiful"
     ],
-    "moji": "🌹"
+    "moji": "🌹",
+    "emoji_order": 295
   },
   "rosette": {
     "unicode": "1F3F5",
@@ -26236,7 +27645,8 @@
       "flower",
       "tropical"
     ],
-    "moji": "🏵"
+    "moji": "🏵",
+    "emoji_order": 455
   },
   "rotating_light": {
     "unicode": "1F6A8",
@@ -26255,7 +27665,8 @@
       "transportation",
       "object"
     ],
-    "moji": "🚨"
+    "moji": "🚨",
+    "emoji_order": 491
   },
   "round_pushpin": {
     "unicode": "1F4CD",
@@ -26270,7 +27681,8 @@
       "object",
       "office"
     ],
-    "moji": "📍"
+    "moji": "📍",
+    "emoji_order": 752
   },
   "rowboat": {
     "unicode": "1F6A3",
@@ -26295,7 +27707,8 @@
       "rowing",
       "diversity"
     ],
-    "moji": "🚣"
+    "moji": "🚣",
+    "emoji_order": 440
   },
   "rowboat_tone1": {
     "unicode": "1F6A3-1F3FB",
@@ -26314,7 +27727,8 @@
       "oar",
       "paddle"
     ],
-    "moji": "🚣🏻"
+    "moji": "🚣🏻",
+    "emoji_order": 1570
   },
   "rowboat_tone2": {
     "unicode": "1F6A3-1F3FC",
@@ -26333,7 +27747,8 @@
       "oar",
       "paddle"
     ],
-    "moji": "🚣🏼"
+    "moji": "🚣🏼",
+    "emoji_order": 1571
   },
   "rowboat_tone3": {
     "unicode": "1F6A3-1F3FD",
@@ -26352,7 +27767,8 @@
       "oar",
       "paddle"
     ],
-    "moji": "🚣🏽"
+    "moji": "🚣🏽",
+    "emoji_order": 1572
   },
   "rowboat_tone4": {
     "unicode": "1F6A3-1F3FE",
@@ -26371,7 +27787,8 @@
       "oar",
       "paddle"
     ],
-    "moji": "🚣🏾"
+    "moji": "🚣🏾",
+    "emoji_order": 1573
   },
   "rowboat_tone5": {
     "unicode": "1F6A3-1F3FF",
@@ -26390,7 +27807,8 @@
       "oar",
       "paddle"
     ],
-    "moji": "🚣🏿"
+    "moji": "🚣🏿",
+    "emoji_order": 1574
   },
   "rugby_football": {
     "unicode": "1F3C9",
@@ -26410,7 +27828,8 @@
       "england",
       "game"
     ],
-    "moji": "🏉"
+    "moji": "🏉",
+    "emoji_order": 425
   },
   "runner": {
     "unicode": "1F3C3",
@@ -26435,7 +27854,8 @@
       "diversity",
       "boys night"
     ],
-    "moji": "🏃"
+    "moji": "🏃",
+    "emoji_order": 140
   },
   "runner_tone1": {
     "unicode": "1F3C3-1F3FB",
@@ -26455,7 +27875,8 @@
       "dash",
       "marathon"
     ],
-    "moji": "🏃🏻"
+    "moji": "🏃🏻",
+    "emoji_order": 1515
   },
   "runner_tone2": {
     "unicode": "1F3C3-1F3FC",
@@ -26475,7 +27896,8 @@
       "dash",
       "marathon"
     ],
-    "moji": "🏃🏼"
+    "moji": "🏃🏼",
+    "emoji_order": 1516
   },
   "runner_tone3": {
     "unicode": "1F3C3-1F3FD",
@@ -26495,7 +27917,8 @@
       "dash",
       "marathon"
     ],
-    "moji": "🏃🏽"
+    "moji": "🏃🏽",
+    "emoji_order": 1517
   },
   "runner_tone4": {
     "unicode": "1F3C3-1F3FE",
@@ -26515,7 +27938,8 @@
       "dash",
       "marathon"
     ],
-    "moji": "🏃🏾"
+    "moji": "🏃🏾",
+    "emoji_order": 1518
   },
   "runner_tone5": {
     "unicode": "1F3C3-1F3FF",
@@ -26535,7 +27959,8 @@
       "dash",
       "marathon"
     ],
-    "moji": "🏃🏿"
+    "moji": "🏃🏿",
+    "emoji_order": 1519
   },
   "running_shirt_with_sash": {
     "unicode": "1F3BD",
@@ -26556,7 +27981,8 @@
       "sports",
       "award"
     ],
-    "moji": "🎽"
+    "moji": "🎽",
+    "emoji_order": 451
   },
   "sa": {
     "unicode": "1F202",
@@ -26572,7 +27998,8 @@
       "symbol",
       "word"
     ],
-    "moji": "🈂"
+    "moji": "🈂",
+    "emoji_order": 878
   },
   "sagittarius": {
     "unicode": "2650",
@@ -26597,7 +28024,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♐"
+    "moji": "♐",
+    "emoji_order": 804
   },
   "sailboat": {
     "unicode": "26F5",
@@ -26616,7 +28044,8 @@
       "boat",
       "vacation"
     ],
-    "moji": "⛵"
+    "moji": "⛵",
+    "emoji_order": 516
   },
   "sake": {
     "unicode": "1F376",
@@ -26639,7 +28068,8 @@
       "japan",
       "girls night"
     ],
-    "moji": "🍶"
+    "moji": "🍶",
+    "emoji_order": 413
   },
   "salad": {
     "unicode": "1F957",
@@ -26652,7 +28082,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥗"
+    "moji": "🥗",
+    "emoji_order": 10144
   },
   "sandal": {
     "unicode": "1F461",
@@ -26668,7 +28099,8 @@
       "shoe",
       "accessories"
     ],
-    "moji": "👡"
+    "moji": "👡",
+    "emoji_order": 187
   },
   "santa": {
     "unicode": "1F385",
@@ -26703,7 +28135,8 @@
       "holidays",
       "diversity"
     ],
-    "moji": "🎅"
+    "moji": "🎅",
+    "emoji_order": 135
   },
   "santa_tone1": {
     "unicode": "1F385-1F3FB",
@@ -26730,7 +28163,8 @@
       "sleigh",
       "holiday"
     ],
-    "moji": "🎅🏻"
+    "moji": "🎅🏻",
+    "emoji_order": 1490
   },
   "santa_tone2": {
     "unicode": "1F385-1F3FC",
@@ -26757,7 +28191,8 @@
       "sleigh",
       "holiday"
     ],
-    "moji": "🎅🏼"
+    "moji": "🎅🏼",
+    "emoji_order": 1491
   },
   "santa_tone3": {
     "unicode": "1F385-1F3FD",
@@ -26784,7 +28219,8 @@
       "sleigh",
       "holiday"
     ],
-    "moji": "🎅🏽"
+    "moji": "🎅🏽",
+    "emoji_order": 1492
   },
   "santa_tone4": {
     "unicode": "1F385-1F3FE",
@@ -26811,7 +28247,8 @@
       "sleigh",
       "holiday"
     ],
-    "moji": "🎅🏾"
+    "moji": "🎅🏾",
+    "emoji_order": 1493
   },
   "santa_tone5": {
     "unicode": "1F385-1F3FF",
@@ -26838,7 +28275,8 @@
       "sleigh",
       "holiday"
     ],
-    "moji": "🎅🏿"
+    "moji": "🎅🏿",
+    "emoji_order": 1494
   },
   "satellite": {
     "unicode": "1F4E1",
@@ -26852,7 +28290,8 @@
       "communication",
       "object"
     ],
-    "moji": "📡"
+    "moji": "📡",
+    "emoji_order": 628
   },
   "satellite_orbital": {
     "unicode": "1F6F0",
@@ -26868,7 +28307,8 @@
       "space",
       "object"
     ],
-    "moji": "🛰"
+    "moji": "🛰",
+    "emoji_order": 522
   },
   "saxophone": {
     "unicode": "1F3B7",
@@ -26886,7 +28326,8 @@
       "woodwind",
       "instruments"
     ],
-    "moji": "🎷"
+    "moji": "🎷",
+    "emoji_order": 465
   },
   "scales": {
     "unicode": "2696",
@@ -26905,7 +28346,8 @@
       "weight",
       "zodiac"
     ],
-    "moji": "⚖"
+    "moji": "⚖",
+    "emoji_order": 644
   },
   "school": {
     "unicode": "1F3EB",
@@ -26927,7 +28369,8 @@
       "education",
       "places"
     ],
-    "moji": "🏫"
+    "moji": "🏫",
+    "emoji_order": 582
   },
   "school_satchel": {
     "unicode": "1F392",
@@ -26955,7 +28398,8 @@
       "vacation",
       "accessories"
     ],
-    "moji": "🎒"
+    "moji": "🎒",
+    "emoji_order": 196
   },
   "scissors": {
     "unicode": "2702",
@@ -26975,7 +28419,8 @@
       "weapon",
       "office"
     ],
-    "moji": "✂"
+    "moji": "✂",
+    "emoji_order": 748
   },
   "scooter": {
     "unicode": "1F6F4",
@@ -26986,7 +28431,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🛴"
+    "moji": "🛴",
+    "emoji_order": 10152
   },
   "scorpion": {
     "unicode": "1F982",
@@ -27001,7 +28447,8 @@
       "reptile",
       "animal"
     ],
-    "moji": "🦂"
+    "moji": "🦂",
+    "emoji_order": 241
   },
   "scorpius": {
     "unicode": "264F",
@@ -27026,7 +28473,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♏"
+    "moji": "♏",
+    "emoji_order": 803
   },
   "scream": {
     "unicode": "1F631",
@@ -27049,7 +28497,8 @@
       "emotion",
       "omg"
     ],
-    "moji": "😱"
+    "moji": "😱",
+    "emoji_order": 51
   },
   "scream_cat": {
     "unicode": "1F640",
@@ -27076,7 +28525,8 @@
       "artist",
       "cat"
     ],
-    "moji": "🙀"
+    "moji": "🙀",
+    "emoji_order": 85
   },
   "scroll": {
     "unicode": "1F4DC",
@@ -27091,7 +28541,8 @@
       "object",
       "office"
     ],
-    "moji": "📜"
+    "moji": "📜",
+    "emoji_order": 715
   },
   "seat": {
     "unicode": "1F4BA",
@@ -27108,7 +28559,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "💺"
+    "moji": "💺",
+    "emoji_order": 523
   },
   "second_place": {
     "unicode": "1F948",
@@ -27121,7 +28573,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥈"
+    "moji": "🥈",
+    "emoji_order": 10165
   },
   "secret": {
     "unicode": "3299",
@@ -27138,7 +28591,8 @@
       "japan",
       "symbol"
     ],
-    "moji": "㊙"
+    "moji": "㊙",
+    "emoji_order": 826
   },
   "see_no_evil": {
     "unicode": "1F648",
@@ -27158,7 +28612,8 @@
       "sight",
       "mizaru"
     ],
-    "moji": "🙈"
+    "moji": "🙈",
+    "emoji_order": 221
   },
   "seedling": {
     "unicode": "1F331",
@@ -27179,7 +28634,8 @@
       "grow",
       "leaf"
     ],
-    "moji": "🌱"
+    "moji": "🌱",
+    "emoji_order": 283
   },
   "selfie": {
     "unicode": "1F933",
@@ -27190,7 +28646,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤳"
+    "moji": "🤳",
+    "emoji_order": 10116
   },
   "selfie_tone1": {
     "unicode": "1F933-1F3FB",
@@ -27201,7 +28658,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤳🏻"
+    "moji": "🤳🏻",
+    "emoji_order": 10035
   },
   "selfie_tone2": {
     "unicode": "1F933-1F3FC",
@@ -27212,7 +28670,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤳🏼"
+    "moji": "🤳🏼",
+    "emoji_order": 10036
   },
   "selfie_tone3": {
     "unicode": "1F933-1F3FD",
@@ -27223,7 +28682,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤳🏽"
+    "moji": "🤳🏽",
+    "emoji_order": 10037
   },
   "selfie_tone4": {
     "unicode": "1F933-1F3FE",
@@ -27234,7 +28694,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤳🏾"
+    "moji": "🤳🏾",
+    "emoji_order": 10038
   },
   "selfie_tone5": {
     "unicode": "1F933-1F3FF",
@@ -27245,7 +28706,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤳🏿"
+    "moji": "🤳🏿",
+    "emoji_order": 10039
   },
   "seven": {
     "moji": "7️⃣",
@@ -27266,7 +28728,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 909
   },
   "shallow_pan_of_food": {
     "unicode": "1F958",
@@ -27281,7 +28744,8 @@
     "keywords": [
       "pan of food"
     ],
-    "moji": "🥘"
+    "moji": "🥘",
+    "emoji_order": 10145
   },
   "shamrock": {
     "unicode": "2618",
@@ -27297,7 +28761,8 @@
       "luck",
       "leaf"
     ],
-    "moji": "☘"
+    "moji": "☘",
+    "emoji_order": 285
   },
   "shark": {
     "unicode": "1F988",
@@ -27308,7 +28773,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦈"
+    "moji": "🦈",
+    "emoji_order": 10128
   },
   "shaved_ice": {
     "unicode": "1F367",
@@ -27329,7 +28795,8 @@
       "flavoring",
       "food"
     ],
-    "moji": "🍧"
+    "moji": "🍧",
+    "emoji_order": 395
   },
   "sheep": {
     "unicode": "1F411",
@@ -27350,7 +28817,8 @@
       "female",
       "lamb"
     ],
-    "moji": "🐑"
+    "moji": "🐑",
+    "emoji_order": 262
   },
   "shell": {
     "unicode": "1F41A",
@@ -27370,7 +28838,8 @@
       "crab",
       "nautilus"
     ],
-    "moji": "🐚"
+    "moji": "🐚",
+    "emoji_order": 303
   },
   "shield": {
     "unicode": "1F6E1",
@@ -27387,7 +28856,8 @@
       "highway",
       "object"
     ],
-    "moji": "🛡"
+    "moji": "🛡",
+    "emoji_order": 658
   },
   "shinto_shrine": {
     "unicode": "26E9",
@@ -27405,7 +28875,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "⛩"
+    "moji": "⛩",
+    "emoji_order": 590
   },
   "ship": {
     "unicode": "1F6A2",
@@ -27424,7 +28895,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "🚢"
+    "moji": "🚢",
+    "emoji_order": 531
   },
   "shirt": {
     "unicode": "1F455",
@@ -27438,7 +28910,8 @@
       "cloth",
       "fashion"
     ],
-    "moji": "👕"
+    "moji": "👕",
+    "emoji_order": 177
   },
   "shopping_bags": {
     "unicode": "1F6CD",
@@ -27458,7 +28931,8 @@
       "birthday",
       "parties"
     ],
-    "moji": "🛍"
+    "moji": "🛍",
+    "emoji_order": 690
   },
   "shopping_cart": {
     "unicode": "1F6D2",
@@ -27471,7 +28945,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🛒"
+    "moji": "🛒",
+    "emoji_order": 10151
   },
   "shower": {
     "unicode": "1F6BF",
@@ -27493,7 +28968,8 @@
       "lather",
       "object"
     ],
-    "moji": "🚿"
+    "moji": "🚿",
+    "emoji_order": 677
   },
   "shrimp": {
     "unicode": "1F990",
@@ -27504,7 +28980,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦐"
+    "moji": "🦐",
+    "emoji_order": 10168
   },
   "shrug": {
     "unicode": "1F937",
@@ -27515,7 +28992,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤷"
+    "moji": "🤷",
+    "emoji_order": 10114
   },
   "shrug_tone1": {
     "unicode": "1F937-1F3FB",
@@ -27526,7 +29004,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤷🏻"
+    "moji": "🤷🏻",
+    "emoji_order": 10015
   },
   "shrug_tone2": {
     "unicode": "1F937-1F3FC",
@@ -27537,7 +29016,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤷🏼"
+    "moji": "🤷🏼",
+    "emoji_order": 10016
   },
   "shrug_tone3": {
     "unicode": "1F937-1F3FD",
@@ -27548,7 +29028,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤷🏽"
+    "moji": "🤷🏽",
+    "emoji_order": 10017
   },
   "shrug_tone4": {
     "unicode": "1F937-1F3FE",
@@ -27559,7 +29040,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤷🏾"
+    "moji": "🤷🏾",
+    "emoji_order": 10018
   },
   "shrug_tone5": {
     "unicode": "1F937-1F3FF",
@@ -27570,7 +29052,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤷🏿"
+    "moji": "🤷🏿",
+    "emoji_order": 10019
   },
   "signal_strength": {
     "unicode": "1F4F6",
@@ -27584,7 +29067,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "📶"
+    "moji": "📶",
+    "emoji_order": 894
   },
   "six": {
     "moji": "6️⃣",
@@ -27604,7 +29088,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 908
   },
   "six_pointed_star": {
     "unicode": "1F52F",
@@ -27621,7 +29106,8 @@
       "star",
       "symbol"
     ],
-    "moji": "🔯"
+    "moji": "🔯",
+    "emoji_order": 790
   },
   "ski": {
     "unicode": "1F3BF",
@@ -27648,7 +29134,8 @@
       "sport",
       "skiing"
     ],
-    "moji": "🎿"
+    "moji": "🎿",
+    "emoji_order": 434
   },
   "skier": {
     "unicode": "26F7",
@@ -27669,7 +29156,8 @@
       "cold",
       "skiing"
     ],
-    "moji": "⛷"
+    "moji": "⛷",
+    "emoji_order": 435
   },
   "skull": {
     "unicode": "1F480",
@@ -27688,7 +29176,8 @@
       "halloween",
       "skull"
     ],
-    "moji": "💀"
+    "moji": "💀",
+    "emoji_order": 75
   },
   "skull_crossbones": {
     "unicode": "2620",
@@ -27710,7 +29199,8 @@
       "dead",
       "skull"
     ],
-    "moji": "☠"
+    "moji": "☠",
+    "emoji_order": 660
   },
   "sleeping": {
     "unicode": "1F634",
@@ -27731,7 +29221,8 @@
       "emotion",
       "goodnight"
     ],
-    "moji": "😴"
+    "moji": "😴",
+    "emoji_order": 68
   },
   "sleeping_accommodation": {
     "unicode": "1F6CC",
@@ -27747,7 +29238,8 @@
       "rest",
       "tired"
     ],
-    "moji": "🛌"
+    "moji": "🛌",
+    "emoji_order": 682
   },
   "sleepy": {
     "unicode": "1F62A",
@@ -27767,7 +29259,8 @@
       "sick",
       "emotion"
     ],
-    "moji": "😪"
+    "moji": "😪",
+    "emoji_order": 59
   },
   "slight_frown": {
     "unicode": "1F641",
@@ -27788,7 +29281,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "🙁"
+    "moji": "🙁",
+    "emoji_order": 43
   },
   "slight_smile": {
     "unicode": "1F642",
@@ -27806,7 +29300,8 @@
       "happy",
       "smiley"
     ],
-    "moji": "🙂"
+    "moji": "🙂",
+    "emoji_order": 12
   },
   "slot_machine": {
     "unicode": "1F3B0",
@@ -27828,7 +29323,8 @@
       "game",
       "boys night"
     ],
-    "moji": "🎰"
+    "moji": "🎰",
+    "emoji_order": 474
   },
   "small_blue_diamond": {
     "unicode": "1F539",
@@ -27843,7 +29339,8 @@
       "shapes",
       "symbol"
     ],
-    "moji": "🔹"
+    "moji": "🔹",
+    "emoji_order": 980
   },
   "small_orange_diamond": {
     "unicode": "1F538",
@@ -27858,7 +29355,8 @@
       "shapes",
       "symbol"
     ],
-    "moji": "🔸"
+    "moji": "🔸",
+    "emoji_order": 979
   },
   "small_red_triangle": {
     "unicode": "1F53A",
@@ -27874,7 +29372,8 @@
       "symbol",
       "triangle"
     ],
-    "moji": "🔺"
+    "moji": "🔺",
+    "emoji_order": 983
   },
   "small_red_triangle_down": {
     "unicode": "1F53B",
@@ -27890,7 +29389,8 @@
       "symbol",
       "triangle"
     ],
-    "moji": "🔻"
+    "moji": "🔻",
+    "emoji_order": 988
   },
   "smile": {
     "unicode": "1F604",
@@ -27918,7 +29418,8 @@
       "smiling",
       "emotion"
     ],
-    "moji": "😄"
+    "moji": "😄",
+    "emoji_order": 6
   },
   "smile_cat": {
     "unicode": "1F638",
@@ -27937,7 +29438,8 @@
       "grinning",
       "happy"
     ],
-    "moji": "😸"
+    "moji": "😸",
+    "emoji_order": 80
   },
   "smiley": {
     "unicode": "1F603",
@@ -27962,7 +29464,8 @@
       "emotion",
       "good"
     ],
-    "moji": "😃"
+    "moji": "😃",
+    "emoji_order": 5
   },
   "smiley_cat": {
     "unicode": "1F63A",
@@ -27980,7 +29483,8 @@
       "smiley",
       "cat"
     ],
-    "moji": "😺"
+    "moji": "😺",
+    "emoji_order": 79
   },
   "smiling_imp": {
     "unicode": "1F608",
@@ -28001,7 +29505,8 @@
       "monster",
       "boys night"
     ],
-    "moji": "😈"
+    "moji": "😈",
+    "emoji_order": 71
   },
   "smirk": {
     "unicode": "1F60F",
@@ -28025,7 +29530,8 @@
       "sexy",
       "sarcastic"
     ],
-    "moji": "😏"
+    "moji": "😏",
+    "emoji_order": 29
   },
   "smirk_cat": {
     "unicode": "1F63C",
@@ -28045,7 +29551,8 @@
       "confidence",
       "cat"
     ],
-    "moji": "😼"
+    "moji": "😼",
+    "emoji_order": 83
   },
   "smoking": {
     "unicode": "1F6AC",
@@ -28069,7 +29576,8 @@
       "symbol",
       "drugs"
     ],
-    "moji": "🚬"
+    "moji": "🚬",
+    "emoji_order": 659
   },
   "snail": {
     "unicode": "1F40C",
@@ -28089,7 +29597,8 @@
       "appetizer",
       "insects"
     ],
-    "moji": "🐌"
+    "moji": "🐌",
+    "emoji_order": 237
   },
   "snake": {
     "unicode": "1F40D",
@@ -28106,7 +29615,8 @@
       "reptile",
       "creationism"
     ],
-    "moji": "🐍"
+    "moji": "🐍",
+    "emoji_order": 243
   },
   "sneezing_face": {
     "unicode": "1F927",
@@ -28119,7 +29629,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤧"
+    "moji": "🤧",
+    "emoji_order": 10109
   },
   "snowboarder": {
     "unicode": "1F3C2",
@@ -28145,7 +29656,8 @@
       "sport",
       "snowboarding"
     ],
-    "moji": "🏂"
+    "moji": "🏂",
+    "emoji_order": 436
   },
   "snowflake": {
     "unicode": "2744",
@@ -28178,7 +29690,8 @@
       "sky",
       "holidays"
     ],
-    "moji": "❄"
+    "moji": "❄",
+    "emoji_order": 339
   },
   "snowman": {
     "unicode": "26C4",
@@ -28200,7 +29713,8 @@
       "holidays",
       "snow"
     ],
-    "moji": "⛄"
+    "moji": "⛄",
+    "emoji_order": 342
   },
   "snowman2": {
     "unicode": "2603",
@@ -28219,7 +29733,8 @@
       "holidays",
       "christmas"
     ],
-    "moji": "☃"
+    "moji": "☃",
+    "emoji_order": 341
   },
   "sob": {
     "unicode": "1F62D",
@@ -28244,7 +29759,8 @@
       "emotion",
       "heartbreak"
     ],
-    "moji": "😭"
+    "moji": "😭",
+    "emoji_order": 61
   },
   "soccer": {
     "unicode": "26BD",
@@ -28267,7 +29783,8 @@
       "sport",
       "soccer"
     ],
-    "moji": "⚽"
+    "moji": "⚽",
+    "emoji_order": 419
   },
   "soon": {
     "unicode": "1F51C",
@@ -28282,7 +29799,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🔜"
+    "moji": "🔜",
+    "emoji_order": 972
   },
   "sos": {
     "unicode": "1F198",
@@ -28299,7 +29817,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🆘"
+    "moji": "🆘",
+    "emoji_order": 836
   },
   "sound": {
     "unicode": "1F509",
@@ -28315,7 +29834,8 @@
       "alarm",
       "symbol"
     ],
-    "moji": "🔉"
+    "moji": "🔉",
+    "emoji_order": 996
   },
   "space_invader": {
     "unicode": "1F47E",
@@ -28331,7 +29851,8 @@
       "monster",
       "alien"
     ],
-    "moji": "👾"
+    "moji": "👾",
+    "emoji_order": 471
   },
   "spades": {
     "unicode": "2660",
@@ -28349,7 +29870,8 @@
       "symbol",
       "game"
     ],
-    "moji": "♠"
+    "moji": "♠",
+    "emoji_order": 1005
   },
   "spaghetti": {
     "unicode": "1F35D",
@@ -28369,7 +29891,8 @@
       "sauce",
       "pasta"
     ],
-    "moji": "🍝"
+    "moji": "🍝",
+    "emoji_order": 381
   },
   "sparkle": {
     "unicode": "2747",
@@ -28386,7 +29909,8 @@
       "stars",
       "symbol"
     ],
-    "moji": "❇"
+    "moji": "❇",
+    "emoji_order": 868
   },
   "sparkler": {
     "unicode": "1F387",
@@ -28402,7 +29926,8 @@
       "stars",
       "parties"
     ],
-    "moji": "🎇"
+    "moji": "🎇",
+    "emoji_order": 563
   },
   "sparkles": {
     "unicode": "2728",
@@ -28420,7 +29945,8 @@
       "star",
       "girls night"
     ],
-    "moji": "✨"
+    "moji": "✨",
+    "emoji_order": 325
   },
   "sparkling_heart": {
     "unicode": "1F496",
@@ -28438,7 +29964,8 @@
       "symbol",
       "girls night"
     ],
-    "moji": "💖"
+    "moji": "💖",
+    "emoji_order": 780
   },
   "speak_no_evil": {
     "unicode": "1F64A",
@@ -28460,7 +29987,8 @@
       "oral",
       "iwazaru"
     ],
-    "moji": "🙊"
+    "moji": "🙊",
+    "emoji_order": 223
   },
   "speaker": {
     "unicode": "1F508",
@@ -28478,7 +30006,8 @@
       "alarm",
       "symbol"
     ],
-    "moji": "🔈"
+    "moji": "🔈",
+    "emoji_order": 995
   },
   "speaking_head": {
     "unicode": "1F5E3",
@@ -28494,7 +30023,8 @@
       "talk",
       "people"
     ],
-    "moji": "🗣"
+    "moji": "🗣",
+    "emoji_order": 120
   },
   "speech_balloon": {
     "unicode": "1F4AC",
@@ -28517,7 +30047,8 @@
       "symbol",
       "free speech"
     ],
-    "moji": "💬"
+    "moji": "💬",
+    "emoji_order": 1012
   },
   "speedboat": {
     "unicode": "1F6A4",
@@ -28540,7 +30071,8 @@
       "vacation",
       "tropical"
     ],
-    "moji": "🚤"
+    "moji": "🚤",
+    "emoji_order": 518
   },
   "spider": {
     "unicode": "1F577",
@@ -28557,7 +30089,8 @@
       "halloween",
       "animal"
     ],
-    "moji": "🕷"
+    "moji": "🕷",
+    "emoji_order": 240
   },
   "spider_web": {
     "unicode": "1F578",
@@ -28571,7 +30104,8 @@
       "cobweb",
       "halloween"
     ],
-    "moji": "🕸"
+    "moji": "🕸",
+    "emoji_order": 304
   },
   "spoon": {
     "unicode": "1F944",
@@ -28582,7 +30116,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥄"
+    "moji": "🥄",
+    "emoji_order": 10149
   },
   "spy": {
     "unicode": "1F575",
@@ -28605,7 +30140,8 @@
       "diversity",
       "job"
     ],
-    "moji": "🕵"
+    "moji": "🕵",
+    "emoji_order": 134
   },
   "spy_tone1": {
     "unicode": "1F575-1F3FB",
@@ -28623,7 +30159,8 @@
       "investigator",
       "person"
     ],
-    "moji": "🕵🏻"
+    "moji": "🕵🏻",
+    "emoji_order": 1615
   },
   "spy_tone2": {
     "unicode": "1F575-1F3FC",
@@ -28641,7 +30178,8 @@
       "investigator",
       "person"
     ],
-    "moji": "🕵🏼"
+    "moji": "🕵🏼",
+    "emoji_order": 1616
   },
   "spy_tone3": {
     "unicode": "1F575-1F3FD",
@@ -28659,7 +30197,8 @@
       "investigator",
       "person"
     ],
-    "moji": "🕵🏽"
+    "moji": "🕵🏽",
+    "emoji_order": 1617
   },
   "spy_tone4": {
     "unicode": "1F575-1F3FE",
@@ -28677,7 +30216,8 @@
       "investigator",
       "person"
     ],
-    "moji": "🕵🏾"
+    "moji": "🕵🏾",
+    "emoji_order": 1618
   },
   "spy_tone5": {
     "unicode": "1F575-1F3FF",
@@ -28695,7 +30235,8 @@
       "investigator",
       "person"
     ],
-    "moji": "🕵🏿"
+    "moji": "🕵🏿",
+    "emoji_order": 1619
   },
   "squid": {
     "unicode": "1F991",
@@ -28706,7 +30247,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🦑"
+    "moji": "🦑",
+    "emoji_order": 10169
   },
   "stadium": {
     "unicode": "1F3DF",
@@ -28728,7 +30270,8 @@
       "vacation",
       "boys night"
     ],
-    "moji": "🏟"
+    "moji": "🏟",
+    "emoji_order": 569
   },
   "star": {
     "unicode": "2B50",
@@ -28747,7 +30290,8 @@
       "sky",
       "star"
     ],
-    "moji": "⭐"
+    "moji": "⭐",
+    "emoji_order": 322
   },
   "star2": {
     "unicode": "1F31F",
@@ -28769,7 +30313,8 @@
       "space",
       "sky"
     ],
-    "moji": "🌟"
+    "moji": "🌟",
+    "emoji_order": 323
   },
   "star_and_crescent": {
     "unicode": "262A",
@@ -28785,7 +30330,8 @@
       "religion",
       "symbol"
     ],
-    "moji": "☪"
+    "moji": "☪",
+    "emoji_order": 786
   },
   "star_of_david": {
     "unicode": "2721",
@@ -28802,7 +30348,8 @@
       "symbol",
       "star"
     ],
-    "moji": "✡"
+    "moji": "✡",
+    "emoji_order": 789
   },
   "stars": {
     "unicode": "1F320",
@@ -28823,7 +30370,8 @@
       "meteoroid",
       "space"
     ],
-    "moji": "🌠"
+    "moji": "🌠",
+    "emoji_order": 562
   },
   "station": {
     "unicode": "1F689",
@@ -28842,7 +30390,8 @@
       "subway",
       "travel"
     ],
-    "moji": "🚉"
+    "moji": "🚉",
+    "emoji_order": 510
   },
   "statue_of_liberty": {
     "unicode": "1F5FD",
@@ -28862,7 +30411,8 @@
       "statue of liberty",
       "free speech"
     ],
-    "moji": "🗽"
+    "moji": "🗽",
+    "emoji_order": 570
   },
   "steam_locomotive": {
     "unicode": "1F682",
@@ -28881,7 +30431,8 @@
       "engine",
       "travel"
     ],
-    "moji": "🚂"
+    "moji": "🚂",
+    "emoji_order": 506
   },
   "stew": {
     "unicode": "1F372",
@@ -28902,7 +30453,8 @@
       "pot",
       "steam"
     ],
-    "moji": "🍲"
+    "moji": "🍲",
+    "emoji_order": 385
   },
   "stop_button": {
     "unicode": "23F9",
@@ -28917,7 +30469,8 @@
       "symbol",
       "square"
     ],
-    "moji": "⏹"
+    "moji": "⏹",
+    "emoji_order": 917
   },
   "stopwatch": {
     "unicode": "23F1",
@@ -28933,7 +30486,8 @@
       "time",
       "electronics"
     ],
-    "moji": "⏱"
+    "moji": "⏱",
+    "emoji_order": 622
   },
   "straight_ruler": {
     "unicode": "1F4CF",
@@ -28949,7 +30503,8 @@
       "tool",
       "office"
     ],
-    "moji": "📏"
+    "moji": "📏",
+    "emoji_order": 750
   },
   "strawberry": {
     "unicode": "1F353",
@@ -28968,7 +30523,8 @@
       "cake",
       "berry"
     ],
-    "moji": "🍓"
+    "moji": "🍓",
+    "emoji_order": 360
   },
   "stuck_out_tongue": {
     "unicode": "1F61B",
@@ -29005,7 +30561,8 @@
       "sex",
       "emotion"
     ],
-    "moji": "😛"
+    "moji": "😛",
+    "emoji_order": 24
   },
   "stuck_out_tongue_closed_eyes": {
     "unicode": "1F61D",
@@ -29028,7 +30585,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😝"
+    "moji": "😝",
+    "emoji_order": 23
   },
   "stuck_out_tongue_winking_eye": {
     "unicode": "1F61C",
@@ -29059,7 +30617,8 @@
       "emotion",
       "parties"
     ],
-    "moji": "😜"
+    "moji": "😜",
+    "emoji_order": 22
   },
   "stuffed_flatbread": {
     "unicode": "1F959",
@@ -29072,7 +30631,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥙"
+    "moji": "🥙",
+    "emoji_order": 10146
   },
   "sun_with_face": {
     "unicode": "1F31E",
@@ -29091,7 +30651,8 @@
       "day",
       "hump day"
     ],
-    "moji": "🌞"
+    "moji": "🌞",
+    "emoji_order": 320
   },
   "sunflower": {
     "unicode": "1F33B",
@@ -29110,7 +30671,8 @@
       "seeds",
       "yellow"
     ],
-    "moji": "🌻"
+    "moji": "🌻",
+    "emoji_order": 294
   },
   "sunglasses": {
     "unicode": "1F60E",
@@ -29141,7 +30703,8 @@
       "emojione",
       "boys night"
     ],
-    "moji": "😎"
+    "moji": "😎",
+    "emoji_order": 27
   },
   "sunny": {
     "unicode": "2600",
@@ -29162,7 +30725,8 @@
       "hot",
       "morning"
     ],
-    "moji": "☀"
+    "moji": "☀",
+    "emoji_order": 327
   },
   "sunrise": {
     "unicode": "1F305",
@@ -29187,7 +30751,8 @@
       "day",
       "hump day"
     ],
-    "moji": "🌅"
+    "moji": "🌅",
+    "emoji_order": 551
   },
   "sunrise_over_mountains": {
     "unicode": "1F304",
@@ -29213,7 +30778,8 @@
       "day",
       "camp"
     ],
-    "moji": "🌄"
+    "moji": "🌄",
+    "emoji_order": 552
   },
   "surfer": {
     "unicode": "1F3C4",
@@ -29238,7 +30804,8 @@
       "sport",
       "diversity"
     ],
-    "moji": "🏄"
+    "moji": "🏄",
+    "emoji_order": 442
   },
   "surfer_tone1": {
     "unicode": "1F3C4-1F3FB",
@@ -29257,7 +30824,8 @@
       "ride",
       "swell"
     ],
-    "moji": "🏄🏻"
+    "moji": "🏄🏻",
+    "emoji_order": 1580
   },
   "surfer_tone2": {
     "unicode": "1F3C4-1F3FC",
@@ -29276,7 +30844,8 @@
       "ride",
       "swell"
     ],
-    "moji": "🏄🏼"
+    "moji": "🏄🏼",
+    "emoji_order": 1581
   },
   "surfer_tone3": {
     "unicode": "1F3C4-1F3FD",
@@ -29295,7 +30864,8 @@
       "ride",
       "swell"
     ],
-    "moji": "🏄🏽"
+    "moji": "🏄🏽",
+    "emoji_order": 1582
   },
   "surfer_tone4": {
     "unicode": "1F3C4-1F3FE",
@@ -29314,7 +30884,8 @@
       "ride",
       "swell"
     ],
-    "moji": "🏄🏾"
+    "moji": "🏄🏾",
+    "emoji_order": 1583
   },
   "surfer_tone5": {
     "unicode": "1F3C4-1F3FF",
@@ -29333,7 +30904,8 @@
       "ride",
       "swell"
     ],
-    "moji": "🏄🏿"
+    "moji": "🏄🏿",
+    "emoji_order": 1584
   },
   "sushi": {
     "unicode": "1F363",
@@ -29352,7 +30924,8 @@
       "nigiri",
       "japan"
     ],
-    "moji": "🍣"
+    "moji": "🍣",
+    "emoji_order": 387
   },
   "suspension_railway": {
     "unicode": "1F69F",
@@ -29371,7 +30944,8 @@
       "train",
       "travel"
     ],
-    "moji": "🚟"
+    "moji": "🚟",
+    "emoji_order": 498
   },
   "sweat": {
     "unicode": "1F613",
@@ -29400,7 +30974,8 @@
       "stressed",
       "emotion"
     ],
-    "moji": "😓"
+    "moji": "😓",
+    "emoji_order": 60
   },
   "sweat_drops": {
     "unicode": "1F4A6",
@@ -29416,7 +30991,8 @@
       "stressed",
       "sweat"
     ],
-    "moji": "💦"
+    "moji": "💦",
+    "emoji_order": 350
   },
   "sweat_smile": {
     "unicode": "1F605",
@@ -29445,7 +31021,8 @@
       "workout",
       "emotion"
     ],
-    "moji": "😅"
+    "moji": "😅",
+    "emoji_order": 7
   },
   "sweet_potato": {
     "unicode": "1F360",
@@ -29465,7 +31042,8 @@
       "roast",
       "vegetables"
     ],
-    "moji": "🍠"
+    "moji": "🍠",
+    "emoji_order": 369
   },
   "swimmer": {
     "unicode": "1F3CA",
@@ -29490,7 +31068,8 @@
       "sport",
       "diversity"
     ],
-    "moji": "🏊"
+    "moji": "🏊",
+    "emoji_order": 441
   },
   "swimmer_tone1": {
     "unicode": "1F3CA-1F3FB",
@@ -29511,7 +31090,8 @@
       "breaststroke",
       "backstroke"
     ],
-    "moji": "🏊🏻"
+    "moji": "🏊🏻",
+    "emoji_order": 1575
   },
   "swimmer_tone2": {
     "unicode": "1F3CA-1F3FC",
@@ -29532,7 +31112,8 @@
       "breaststroke",
       "backstroke"
     ],
-    "moji": "🏊🏼"
+    "moji": "🏊🏼",
+    "emoji_order": 1576
   },
   "swimmer_tone3": {
     "unicode": "1F3CA-1F3FD",
@@ -29553,7 +31134,8 @@
       "breaststroke",
       "backstroke"
     ],
-    "moji": "🏊🏽"
+    "moji": "🏊🏽",
+    "emoji_order": 1577
   },
   "swimmer_tone4": {
     "unicode": "1F3CA-1F3FE",
@@ -29574,7 +31156,8 @@
       "breaststroke",
       "backstroke"
     ],
-    "moji": "🏊🏾"
+    "moji": "🏊🏾",
+    "emoji_order": 1578
   },
   "swimmer_tone5": {
     "unicode": "1F3CA-1F3FF",
@@ -29595,7 +31178,8 @@
       "breaststroke",
       "backstroke"
     ],
-    "moji": "🏊🏿"
+    "moji": "🏊🏿",
+    "emoji_order": 1579
   },
   "symbols": {
     "unicode": "1F523",
@@ -29609,7 +31193,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "🔣"
+    "moji": "🔣",
+    "emoji_order": 952
   },
   "synagogue": {
     "unicode": "1F54D",
@@ -29627,7 +31212,8 @@
       "vacation",
       "condolence"
     ],
-    "moji": "🕍"
+    "moji": "🕍",
+    "emoji_order": 588
   },
   "syringe": {
     "unicode": "1F489",
@@ -29647,7 +31233,8 @@
       "object",
       "weapon"
     ],
-    "moji": "💉"
+    "moji": "💉",
+    "emoji_order": 672
   },
   "taco": {
     "unicode": "1F32E",
@@ -29662,7 +31249,8 @@
       "mexican",
       "vagina"
     ],
-    "moji": "🌮"
+    "moji": "🌮",
+    "emoji_order": 382
   },
   "tada": {
     "unicode": "1F389",
@@ -29691,7 +31279,8 @@
       "boys night",
       "parties"
     ],
-    "moji": "🎉"
+    "moji": "🎉",
+    "emoji_order": 696
   },
   "tanabata_tree": {
     "unicode": "1F38B",
@@ -29712,7 +31301,8 @@
       "holiday",
       "trees"
     ],
-    "moji": "🎋"
+    "moji": "🎋",
+    "emoji_order": 288
   },
   "tangerine": {
     "unicode": "1F34A",
@@ -29730,7 +31320,8 @@
       "citrus",
       "orange"
     ],
-    "moji": "🍊"
+    "moji": "🍊",
+    "emoji_order": 355
   },
   "taurus": {
     "unicode": "2649",
@@ -29755,7 +31346,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♉"
+    "moji": "♉",
+    "emoji_order": 797
   },
   "taxi": {
     "unicode": "1F695",
@@ -29778,7 +31370,8 @@
       "service",
       "travel"
     ],
-    "moji": "🚕"
+    "moji": "🚕",
+    "emoji_order": 477
   },
   "tea": {
     "unicode": "1F375",
@@ -29804,7 +31397,8 @@
       "steam",
       "morning"
     ],
-    "moji": "🍵"
+    "moji": "🍵",
+    "emoji_order": 414
   },
   "telephone": {
     "unicode": "260E",
@@ -29823,7 +31417,8 @@
       "electronics",
       "phone"
     ],
-    "moji": "☎"
+    "moji": "☎",
+    "emoji_order": 614
   },
   "telephone_receiver": {
     "unicode": "1F4DE",
@@ -29840,7 +31435,8 @@
       "electronics",
       "phone"
     ],
-    "moji": "📞"
+    "moji": "📞",
+    "emoji_order": 613
   },
   "telescope": {
     "unicode": "1F52D",
@@ -29856,7 +31452,8 @@
       "object",
       "science"
     ],
-    "moji": "🔭"
+    "moji": "🔭",
+    "emoji_order": 668
   },
   "ten": {
     "unicode": "1F51F",
@@ -29875,7 +31472,8 @@
       "number",
       "math"
     ],
-    "moji": "🔟"
+    "moji": "🔟",
+    "emoji_order": 912
   },
   "tennis": {
     "unicode": "1F3BE",
@@ -29899,7 +31497,8 @@
       "love",
       "sport"
     ],
-    "moji": "🎾"
+    "moji": "🎾",
+    "emoji_order": 423
   },
   "tent": {
     "unicode": "26FA",
@@ -29919,7 +31518,8 @@
       "travel",
       "vacation"
     ],
-    "moji": "⛺"
+    "moji": "⛺",
+    "emoji_order": 547
   },
   "thermometer": {
     "unicode": "1F321",
@@ -29936,7 +31536,8 @@
       "health",
       "hot"
     ],
-    "moji": "🌡"
+    "moji": "🌡",
+    "emoji_order": 673
   },
   "thermometer_face": {
     "unicode": "1F912",
@@ -29954,7 +31555,8 @@
       "sick",
       "emotion"
     ],
-    "moji": "🤒"
+    "moji": "🤒",
+    "emoji_order": 66
   },
   "thinking": {
     "unicode": "1F914",
@@ -29971,7 +31573,8 @@
       "thinking",
       "boys night"
     ],
-    "moji": "🤔"
+    "moji": "🤔",
+    "emoji_order": 35
   },
   "third_place": {
     "unicode": "1F949",
@@ -29984,7 +31587,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥉"
+    "moji": "🥉",
+    "emoji_order": 10166
   },
   "thought_balloon": {
     "unicode": "1F4AD",
@@ -30006,7 +31610,8 @@
       "wonder",
       "symbol"
     ],
-    "moji": "💭"
+    "moji": "💭",
+    "emoji_order": 1010
   },
   "three": {
     "moji": "3️⃣",
@@ -30027,7 +31632,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 905
   },
   "thumbsdown": {
     "unicode": "1F44E",
@@ -30046,7 +31652,8 @@
       "hands",
       "diversity"
     ],
-    "moji": "👎"
+    "moji": "👎",
+    "emoji_order": 92
   },
   "thumbsdown_tone1": {
     "unicode": "1F44E-1F3FB",
@@ -30063,7 +31670,8 @@
       "no",
       "-1"
     ],
-    "moji": "👎🏻"
+    "moji": "👎🏻",
+    "emoji_order": 1315
   },
   "thumbsdown_tone2": {
     "unicode": "1F44E-1F3FC",
@@ -30080,7 +31688,8 @@
       "no",
       "-1"
     ],
-    "moji": "👎🏼"
+    "moji": "👎🏼",
+    "emoji_order": 1316
   },
   "thumbsdown_tone3": {
     "unicode": "1F44E-1F3FD",
@@ -30097,7 +31706,8 @@
       "no",
       "-1"
     ],
-    "moji": "👎🏽"
+    "moji": "👎🏽",
+    "emoji_order": 1317
   },
   "thumbsdown_tone4": {
     "unicode": "1F44E-1F3FE",
@@ -30114,7 +31724,8 @@
       "no",
       "-1"
     ],
-    "moji": "👎🏾"
+    "moji": "👎🏾",
+    "emoji_order": 1318
   },
   "thumbsdown_tone5": {
     "unicode": "1F44E-1F3FF",
@@ -30131,7 +31742,8 @@
       "no",
       "-1"
     ],
-    "moji": "👎🏿"
+    "moji": "👎🏿",
+    "emoji_order": 1319
   },
   "thumbsup": {
     "unicode": "1F44D",
@@ -30158,7 +31770,8 @@
       "good",
       "beautiful"
     ],
-    "moji": "👍"
+    "moji": "👍",
+    "emoji_order": 91
   },
   "thumbsup_tone1": {
     "unicode": "1F44D-1F3FB",
@@ -30177,7 +31790,8 @@
       "yes",
       "+1"
     ],
-    "moji": "👍🏻"
+    "moji": "👍🏻",
+    "emoji_order": 1310
   },
   "thumbsup_tone2": {
     "unicode": "1F44D-1F3FC",
@@ -30196,7 +31810,8 @@
       "yes",
       "+1"
     ],
-    "moji": "👍🏼"
+    "moji": "👍🏼",
+    "emoji_order": 1311
   },
   "thumbsup_tone3": {
     "unicode": "1F44D-1F3FD",
@@ -30215,7 +31830,8 @@
       "yes",
       "+1"
     ],
-    "moji": "👍🏽"
+    "moji": "👍🏽",
+    "emoji_order": 1312
   },
   "thumbsup_tone4": {
     "unicode": "1F44D-1F3FE",
@@ -30234,7 +31850,8 @@
       "yes",
       "+1"
     ],
-    "moji": "👍🏾"
+    "moji": "👍🏾",
+    "emoji_order": 1313
   },
   "thumbsup_tone5": {
     "unicode": "1F44D-1F3FF",
@@ -30253,7 +31870,8 @@
       "yes",
       "+1"
     ],
-    "moji": "👍🏿"
+    "moji": "👍🏿",
+    "emoji_order": 1314
   },
   "thunder_cloud_rain": {
     "unicode": "26C8",
@@ -30273,7 +31891,8 @@
       "cold",
       "rain"
     ],
-    "moji": "⛈"
+    "moji": "⛈",
+    "emoji_order": 334
   },
   "ticket": {
     "unicode": "1F3AB",
@@ -30298,7 +31917,8 @@
       "movie",
       "parties"
     ],
-    "moji": "🎫"
+    "moji": "🎫",
+    "emoji_order": 456
   },
   "tickets": {
     "unicode": "1F39F",
@@ -30323,7 +31943,8 @@
       "movie",
       "parties"
     ],
-    "moji": "🎟"
+    "moji": "🎟",
+    "emoji_order": 457
   },
   "tiger": {
     "unicode": "1F42F",
@@ -30339,7 +31960,8 @@
       "roar",
       "cat"
     ],
-    "moji": "🐯"
+    "moji": "🐯",
+    "emoji_order": 213
   },
   "tiger2": {
     "unicode": "1F405",
@@ -30361,7 +31983,8 @@
       "wildlife",
       "roar"
     ],
-    "moji": "🐅"
+    "moji": "🐅",
+    "emoji_order": 253
   },
   "timer": {
     "unicode": "23F2",
@@ -30377,7 +32000,8 @@
       "object",
       "time"
     ],
-    "moji": "⏲"
+    "moji": "⏲",
+    "emoji_order": 623
   },
   "tired_face": {
     "unicode": "1F62B",
@@ -30400,7 +32024,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😫"
+    "moji": "😫",
+    "emoji_order": 47
   },
   "tm": {
     "unicode": "2122",
@@ -30419,7 +32044,8 @@
       "tm",
       "word"
     ],
-    "moji": "™"
+    "moji": "™",
+    "emoji_order": 967
   },
   "toilet": {
     "unicode": "1F6BD",
@@ -30441,7 +32067,8 @@
       "plumbing",
       "object"
     ],
-    "moji": "🚽"
+    "moji": "🚽",
+    "emoji_order": 676
   },
   "tokyo_tower": {
     "unicode": "1F5FC",
@@ -30459,7 +32086,8 @@
       "vacation",
       "eiffel tower"
     ],
-    "moji": "🗼"
+    "moji": "🗼",
+    "emoji_order": 537
   },
   "tomato": {
     "unicode": "1F345",
@@ -30479,7 +32107,8 @@
       "italian",
       "vegetables"
     ],
-    "moji": "🍅"
+    "moji": "🍅",
+    "emoji_order": 365
   },
   "tone1": {
     "unicode": "1F3FB",
@@ -30490,7 +32119,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🏻"
+    "moji": "🏻",
+    "emoji_order": 1620
   },
   "tone2": {
     "unicode": "1F3FC",
@@ -30501,7 +32131,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🏼"
+    "moji": "🏼",
+    "emoji_order": 1621
   },
   "tone3": {
     "unicode": "1F3FD",
@@ -30512,7 +32143,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🏽"
+    "moji": "🏽",
+    "emoji_order": 1622
   },
   "tone4": {
     "unicode": "1F3FE",
@@ -30523,7 +32155,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🏾"
+    "moji": "🏾",
+    "emoji_order": 1623
   },
   "tone5": {
     "unicode": "1F3FF",
@@ -30534,7 +32167,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🏿"
+    "moji": "🏿",
+    "emoji_order": 1624
   },
   "tongue": {
     "unicode": "1F445",
@@ -30564,7 +32198,8 @@
       "sexy",
       "lip"
     ],
-    "moji": "👅"
+    "moji": "👅",
+    "emoji_order": 113
   },
   "tools": {
     "unicode": "1F6E0",
@@ -30581,7 +32216,8 @@
       "object",
       "tool"
     ],
-    "moji": "🛠"
+    "moji": "🛠",
+    "emoji_order": 648
   },
   "top": {
     "unicode": "1F51D",
@@ -30597,7 +32233,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "🔝"
+    "moji": "🔝",
+    "emoji_order": 971
   },
   "tophat": {
     "unicode": "1F3A9",
@@ -30627,7 +32264,8 @@
       "fashion",
       "accessories"
     ],
-    "moji": "🎩"
+    "moji": "🎩",
+    "emoji_order": 192
   },
   "track_next": {
     "unicode": "23ED",
@@ -30646,7 +32284,8 @@
       "sound",
       "symbol"
     ],
-    "moji": "⏭"
+    "moji": "⏭",
+    "emoji_order": 919
   },
   "track_previous": {
     "unicode": "23EE",
@@ -30665,7 +32304,8 @@
       "sound",
       "symbol"
     ],
-    "moji": "⏮"
+    "moji": "⏮",
+    "emoji_order": 920
   },
   "trackball": {
     "unicode": "1F5B2",
@@ -30684,7 +32324,8 @@
       "game",
       "office"
     ],
-    "moji": "🖲"
+    "moji": "🖲",
+    "emoji_order": 599
   },
   "tractor": {
     "unicode": "1F69C",
@@ -30706,7 +32347,8 @@
       "digger",
       "transportation"
     ],
-    "moji": "🚜"
+    "moji": "🚜",
+    "emoji_order": 488
   },
   "traffic_light": {
     "unicode": "1F6A5",
@@ -30727,7 +32369,8 @@
       "object",
       "stop light"
     ],
-    "moji": "🚥"
+    "moji": "🚥",
+    "emoji_order": 529
   },
   "train": {
     "unicode": "1F68B",
@@ -30744,7 +32387,8 @@
       "travel",
       "train"
     ],
-    "moji": "🚋"
+    "moji": "🚋",
+    "emoji_order": 500
   },
   "train2": {
     "unicode": "1F686",
@@ -30762,7 +32406,8 @@
       "rail",
       "travel"
     ],
-    "moji": "🚆"
+    "moji": "🚆",
+    "emoji_order": 507
   },
   "tram": {
     "unicode": "1F68A",
@@ -30780,7 +32425,8 @@
       "travel",
       "train"
     ],
-    "moji": "🚊"
+    "moji": "🚊",
+    "emoji_order": 509
   },
   "triangular_flag_on_post": {
     "unicode": "1F6A9",
@@ -30799,7 +32445,8 @@
       "flagpole",
       "object"
     ],
-    "moji": "🚩"
+    "moji": "🚩",
+    "emoji_order": 753
   },
   "triangular_ruler": {
     "unicode": "1F4D0",
@@ -30818,7 +32465,8 @@
       "tool",
       "office"
     ],
-    "moji": "📐"
+    "moji": "📐",
+    "emoji_order": 749
   },
   "trident": {
     "unicode": "1F531",
@@ -30834,7 +32482,8 @@
       "object",
       "symbol"
     ],
-    "moji": "🔱"
+    "moji": "🔱",
+    "emoji_order": 859
   },
   "triumph": {
     "unicode": "1F624",
@@ -30856,7 +32505,8 @@
       "angry",
       "emotion"
     ],
-    "moji": "😤"
+    "moji": "😤",
+    "emoji_order": 49
   },
   "trolleybus": {
     "unicode": "1F68E",
@@ -30876,7 +32526,8 @@
       "transport",
       "travel"
     ],
-    "moji": "🚎"
+    "moji": "🚎",
+    "emoji_order": 480
   },
   "trophy": {
     "unicode": "1F3C6",
@@ -30904,7 +32555,8 @@
       "perfect",
       "parties"
     ],
-    "moji": "🏆"
+    "moji": "🏆",
+    "emoji_order": 450
   },
   "tropical_drink": {
     "unicode": "1F379",
@@ -30927,7 +32579,8 @@
       "cocktail",
       "alcohol"
     ],
-    "moji": "🍹"
+    "moji": "🍹",
+    "emoji_order": 411
   },
   "tropical_fish": {
     "unicode": "1F420",
@@ -30942,7 +32595,8 @@
       "swim",
       "wildlife"
     ],
-    "moji": "🐠"
+    "moji": "🐠",
+    "emoji_order": 245
   },
   "truck": {
     "unicode": "1F69A",
@@ -30959,7 +32613,8 @@
       "delivery",
       "package"
     ],
-    "moji": "🚚"
+    "moji": "🚚",
+    "emoji_order": 486
   },
   "trumpet": {
     "unicode": "1F3BA",
@@ -30976,7 +32631,8 @@
       "instrument",
       "instruments"
     ],
-    "moji": "🎺"
+    "moji": "🎺",
+    "emoji_order": 466
   },
   "tulip": {
     "unicode": "1F337",
@@ -30998,7 +32654,8 @@
       "vagina",
       "girls night"
     ],
-    "moji": "🌷"
+    "moji": "🌷",
+    "emoji_order": 296
   },
   "tumbler_glass": {
     "unicode": "1F943",
@@ -31013,7 +32670,8 @@
     "keywords": [
       "booze"
     ],
-    "moji": "🥃"
+    "moji": "🥃",
+    "emoji_order": 10148
   },
   "turkey": {
     "unicode": "1F983",
@@ -31027,7 +32685,8 @@
       "wildlife",
       "animal"
     ],
-    "moji": "🦃"
+    "moji": "🦃",
+    "emoji_order": 268
   },
   "turtle": {
     "unicode": "1F422",
@@ -31049,7 +32708,8 @@
       "steady",
       "wildlife"
     ],
-    "moji": "🐢"
+    "moji": "🐢",
+    "emoji_order": 244
   },
   "tv": {
     "unicode": "1F4FA",
@@ -31070,7 +32730,8 @@
       "video",
       "electronics"
     ],
-    "moji": "📺"
+    "moji": "📺",
+    "emoji_order": 617
   },
   "twisted_rightwards_arrows": {
     "unicode": "1F500",
@@ -31085,7 +32746,8 @@
       "arrow",
       "symbol"
     ],
-    "moji": "🔀"
+    "moji": "🔀",
+    "emoji_order": 923
   },
   "two": {
     "moji": "2️⃣",
@@ -31106,7 +32768,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 904
   },
   "two_hearts": {
     "unicode": "1F495",
@@ -31127,7 +32790,8 @@
       "emotion",
       "symbol"
     ],
-    "moji": "💕"
+    "moji": "💕",
+    "emoji_order": 776
   },
   "two_men_holding_hands": {
     "unicode": "1F46C",
@@ -31154,7 +32818,8 @@
       "sex",
       "lgbt"
     ],
-    "moji": "👬"
+    "moji": "👬",
+    "emoji_order": 144
   },
   "two_women_holding_hands": {
     "unicode": "1F46D",
@@ -31185,7 +32850,8 @@
       "lesbian",
       "girls night"
     ],
-    "moji": "👭"
+    "moji": "👭",
+    "emoji_order": 145
   },
   "u5272": {
     "unicode": "1F239",
@@ -31203,7 +32869,8 @@
       "pink",
       "symbol"
     ],
-    "moji": "🈹"
+    "moji": "🈹",
+    "emoji_order": 811
   },
   "u5408": {
     "unicode": "1F234",
@@ -31221,7 +32888,8 @@
       "japan",
       "symbol"
     ],
-    "moji": "🈴"
+    "moji": "🈴",
+    "emoji_order": 828
   },
   "u55b6": {
     "unicode": "1F23A",
@@ -31236,7 +32904,8 @@
       "opening hours",
       "symbol"
     ],
-    "moji": "🈺"
+    "moji": "🈺",
+    "emoji_order": 819
   },
   "u6307": {
     "unicode": "1F22F",
@@ -31255,7 +32924,8 @@
       "point",
       "symbol"
     ],
-    "moji": "🈯"
+    "moji": "🈯",
+    "emoji_order": 866
   },
   "u6708": {
     "unicode": "1F237",
@@ -31273,7 +32943,8 @@
       "orange-square",
       "symbol"
     ],
-    "moji": "🈷"
+    "moji": "🈷",
+    "emoji_order": 820
   },
   "u6709": {
     "unicode": "1F236",
@@ -31290,7 +32961,8 @@
       "orange-square",
       "symbol"
     ],
-    "moji": "🈶"
+    "moji": "🈶",
+    "emoji_order": 816
   },
   "u6e80": {
     "unicode": "1F235",
@@ -31309,7 +32981,8 @@
       "japan",
       "symbol"
     ],
-    "moji": "🈵"
+    "moji": "🈵",
+    "emoji_order": 829
   },
   "u7121": {
     "unicode": "1F21A",
@@ -31330,7 +33003,8 @@
       "orange-square",
       "symbol"
     ],
-    "moji": "🈚"
+    "moji": "🈚",
+    "emoji_order": 817
   },
   "u7533": {
     "unicode": "1F238",
@@ -31346,7 +33020,8 @@
       "kanji",
       "symbol"
     ],
-    "moji": "🈸"
+    "moji": "🈸",
+    "emoji_order": 818
   },
   "u7981": {
     "unicode": "1F232",
@@ -31366,7 +33041,8 @@
       "japan",
       "symbol"
     ],
-    "moji": "🈲"
+    "moji": "🈲",
+    "emoji_order": 830
   },
   "u7a7a": {
     "unicode": "1F233",
@@ -31383,7 +33059,8 @@
       "kanji",
       "symbol"
     ],
-    "moji": "🈳"
+    "moji": "🈳",
+    "emoji_order": 810
   },
   "umbrella": {
     "unicode": "2614",
@@ -31401,7 +33078,8 @@
       "sky",
       "cold"
     ],
-    "moji": "☔"
+    "moji": "☔",
+    "emoji_order": 348
   },
   "umbrella2": {
     "unicode": "2602",
@@ -31420,7 +33098,8 @@
       "sky",
       "cold"
     ],
-    "moji": "☂"
+    "moji": "☂",
+    "emoji_order": 347
   },
   "unamused": {
     "unicode": "1F612",
@@ -31448,7 +33127,8 @@
       "tired",
       "emotion"
     ],
-    "moji": "😒"
+    "moji": "😒",
+    "emoji_order": 33
   },
   "underage": {
     "unicode": "1F51E",
@@ -31465,7 +33145,8 @@
       "pub",
       "symbol"
     ],
-    "moji": "🔞"
+    "moji": "🔞",
+    "emoji_order": 848
   },
   "unicorn": {
     "unicode": "1F984",
@@ -31480,7 +33161,8 @@
     "keywords": [
       "animal"
     ],
-    "moji": "🦄"
+    "moji": "🦄",
+    "emoji_order": 234
   },
   "unlock": {
     "unicode": "1F513",
@@ -31496,7 +33178,8 @@
       "object",
       "lock"
     ],
-    "moji": "🔓"
+    "moji": "🔓",
+    "emoji_order": 758
   },
   "up": {
     "unicode": "1F199",
@@ -31510,7 +33193,8 @@
       "blue-square",
       "symbol"
     ],
-    "moji": "🆙"
+    "moji": "🆙",
+    "emoji_order": 898
   },
   "upside_down": {
     "unicode": "1F643",
@@ -31527,7 +33211,8 @@
       "smiley",
       "sarcastic"
     ],
-    "moji": "🙃"
+    "moji": "🙃",
+    "emoji_order": 13
   },
   "urn": {
     "unicode": "26B1",
@@ -31545,7 +33230,8 @@
       "dead",
       "rip"
     ],
-    "moji": "⚱"
+    "moji": "⚱",
+    "emoji_order": 662
   },
   "v": {
     "unicode": "270C",
@@ -31571,7 +33257,8 @@
       "diversity",
       "girls night"
     ],
-    "moji": "✌"
+    "moji": "✌",
+    "emoji_order": 95
   },
   "v_tone1": {
     "unicode": "270C-1F3FB",
@@ -31588,7 +33275,8 @@
       "two",
       "v"
     ],
-    "moji": "✌🏻"
+    "moji": "✌🏻",
+    "emoji_order": 1330
   },
   "v_tone2": {
     "unicode": "270C-1F3FC",
@@ -31605,7 +33293,8 @@
       "two",
       "v"
     ],
-    "moji": "✌🏼"
+    "moji": "✌🏼",
+    "emoji_order": 1331
   },
   "v_tone3": {
     "unicode": "270C-1F3FD",
@@ -31622,7 +33311,8 @@
       "two",
       "v"
     ],
-    "moji": "✌🏽"
+    "moji": "✌🏽",
+    "emoji_order": 1332
   },
   "v_tone4": {
     "unicode": "270C-1F3FE",
@@ -31639,7 +33329,8 @@
       "two",
       "v"
     ],
-    "moji": "✌🏾"
+    "moji": "✌🏾",
+    "emoji_order": 1333
   },
   "v_tone5": {
     "unicode": "270C-1F3FF",
@@ -31656,7 +33347,8 @@
       "two",
       "v"
     ],
-    "moji": "✌🏿"
+    "moji": "✌🏿",
+    "emoji_order": 1334
   },
   "vertical_traffic_light": {
     "unicode": "1F6A6",
@@ -31677,7 +33369,8 @@
       "object",
       "stop light"
     ],
-    "moji": "🚦"
+    "moji": "🚦",
+    "emoji_order": 528
   },
   "vhs": {
     "unicode": "1F4FC",
@@ -31693,7 +33386,8 @@
       "video",
       "electronics"
     ],
-    "moji": "📼"
+    "moji": "📼",
+    "emoji_order": 606
   },
   "vibration_mode": {
     "unicode": "1F4F3",
@@ -31708,7 +33402,8 @@
       "phone",
       "symbol"
     ],
-    "moji": "📳"
+    "moji": "📳",
+    "emoji_order": 815
   },
   "video_camera": {
     "unicode": "1F4F9",
@@ -31725,7 +33420,8 @@
       "camera",
       "movie"
     ],
-    "moji": "📹"
+    "moji": "📹",
+    "emoji_order": 609
   },
   "video_game": {
     "unicode": "1F3AE",
@@ -31748,7 +33444,8 @@
       "electronics",
       "boys night"
     ],
-    "moji": "🎮"
+    "moji": "🎮",
+    "emoji_order": 470
   },
   "violin": {
     "unicode": "1F3BB",
@@ -31766,7 +33463,8 @@
       "instruments",
       "sarcastic"
     ],
-    "moji": "🎻"
+    "moji": "🎻",
+    "emoji_order": 468
   },
   "virgo": {
     "unicode": "264D",
@@ -31790,7 +33488,8 @@
       "horoscope",
       "symbol"
     ],
-    "moji": "♍"
+    "moji": "♍",
+    "emoji_order": 801
   },
   "volcano": {
     "unicode": "1F30B",
@@ -31811,7 +33510,8 @@
       "places",
       "tropical"
     ],
-    "moji": "🌋"
+    "moji": "🌋",
+    "emoji_order": 544
   },
   "volleyball": {
     "unicode": "1F3D0",
@@ -31827,7 +33527,8 @@
       "sport",
       "volleyball"
     ],
-    "moji": "🏐"
+    "moji": "🏐",
+    "emoji_order": 424
   },
   "vs": {
     "unicode": "1F19A",
@@ -31842,7 +33543,8 @@
       "words",
       "symbol"
     ],
-    "moji": "🆚"
+    "moji": "🆚",
+    "emoji_order": 822
   },
   "vulcan": {
     "unicode": "1F596",
@@ -31866,7 +33568,8 @@
       "hi",
       "diversity"
     ],
-    "moji": "🖖"
+    "moji": "🖖",
+    "emoji_order": 109
   },
   "vulcan_tone1": {
     "unicode": "1F596-1F3FB",
@@ -31886,7 +33589,8 @@
       "star trek",
       "live long"
     ],
-    "moji": "🖖🏻"
+    "moji": "🖖🏻",
+    "emoji_order": 1400
   },
   "vulcan_tone2": {
     "unicode": "1F596-1F3FC",
@@ -31906,7 +33610,8 @@
       "star trek",
       "live long"
     ],
-    "moji": "🖖🏼"
+    "moji": "🖖🏼",
+    "emoji_order": 1401
   },
   "vulcan_tone3": {
     "unicode": "1F596-1F3FD",
@@ -31926,7 +33631,8 @@
       "star trek",
       "live long"
     ],
-    "moji": "🖖🏽"
+    "moji": "🖖🏽",
+    "emoji_order": 1402
   },
   "vulcan_tone4": {
     "unicode": "1F596-1F3FE",
@@ -31946,7 +33652,8 @@
       "star trek",
       "live long"
     ],
-    "moji": "🖖🏾"
+    "moji": "🖖🏾",
+    "emoji_order": 1403
   },
   "vulcan_tone5": {
     "unicode": "1F596-1F3FF",
@@ -31966,7 +33673,8 @@
       "star trek",
       "live long"
     ],
-    "moji": "🖖🏿"
+    "moji": "🖖🏿",
+    "emoji_order": 1404
   },
   "walking": {
     "unicode": "1F6B6",
@@ -31989,7 +33697,8 @@
       "men",
       "diversity"
     ],
-    "moji": "🚶"
+    "moji": "🚶",
+    "emoji_order": 139
   },
   "walking_tone1": {
     "unicode": "1F6B6-1F3FB",
@@ -32007,7 +33716,8 @@
       "hiking",
       "hike"
     ],
-    "moji": "🚶🏻"
+    "moji": "🚶🏻",
+    "emoji_order": 1510
   },
   "walking_tone2": {
     "unicode": "1F6B6-1F3FC",
@@ -32025,7 +33735,8 @@
       "hiking",
       "hike"
     ],
-    "moji": "🚶🏼"
+    "moji": "🚶🏼",
+    "emoji_order": 1511
   },
   "walking_tone3": {
     "unicode": "1F6B6-1F3FD",
@@ -32043,7 +33754,8 @@
       "hiking",
       "hike"
     ],
-    "moji": "🚶🏽"
+    "moji": "🚶🏽",
+    "emoji_order": 1512
   },
   "walking_tone4": {
     "unicode": "1F6B6-1F3FE",
@@ -32061,7 +33773,8 @@
       "hiking",
       "hike"
     ],
-    "moji": "🚶🏾"
+    "moji": "🚶🏾",
+    "emoji_order": 1513
   },
   "walking_tone5": {
     "unicode": "1F6B6-1F3FF",
@@ -32079,7 +33792,8 @@
       "hiking",
       "hike"
     ],
-    "moji": "🚶🏿"
+    "moji": "🚶🏿",
+    "emoji_order": 1514
   },
   "waning_crescent_moon": {
     "unicode": "1F318",
@@ -32100,7 +33814,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌘"
+    "moji": "🌘",
+    "emoji_order": 311
   },
   "waning_gibbous_moon": {
     "unicode": "1F316",
@@ -32121,7 +33836,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌖"
+    "moji": "🌖",
+    "emoji_order": 309
   },
   "warning": {
     "unicode": "26A0",
@@ -32139,7 +33855,8 @@
       "symbol",
       "punctuation"
     ],
-    "moji": "⚠"
+    "moji": "⚠",
+    "emoji_order": 862
   },
   "wastebasket": {
     "unicode": "1F5D1",
@@ -32156,7 +33873,8 @@
       "object",
       "work"
     ],
-    "moji": "🗑"
+    "moji": "🗑",
+    "emoji_order": 634
   },
   "watch": {
     "unicode": "231A",
@@ -32173,7 +33891,8 @@
       "time",
       "electronics"
     ],
-    "moji": "⌚"
+    "moji": "⌚",
+    "emoji_order": 591
   },
   "water_buffalo": {
     "unicode": "1F403",
@@ -32196,7 +33915,8 @@
       "dairy",
       "wildlife"
     ],
-    "moji": "🐃"
+    "moji": "🐃",
+    "emoji_order": 254
   },
   "water_polo": {
     "unicode": "1F93D",
@@ -32207,7 +33927,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤽"
+    "moji": "🤽",
+    "emoji_order": 10160
   },
   "water_polo_tone1": {
     "unicode": "1F93D-1F3FB",
@@ -32218,7 +33939,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤽🏻"
+    "moji": "🤽🏻",
+    "emoji_order": 10085
   },
   "water_polo_tone2": {
     "unicode": "1F93D-1F3FC",
@@ -32229,7 +33951,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤽🏼"
+    "moji": "🤽🏼",
+    "emoji_order": 10086
   },
   "water_polo_tone3": {
     "unicode": "1F93D-1F3FD",
@@ -32240,7 +33963,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤽🏽"
+    "moji": "🤽🏽",
+    "emoji_order": 10087
   },
   "water_polo_tone4": {
     "unicode": "1F93D-1F3FE",
@@ -32251,7 +33975,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤽🏾"
+    "moji": "🤽🏾",
+    "emoji_order": 10088
   },
   "water_polo_tone5": {
     "unicode": "1F93D-1F3FF",
@@ -32262,7 +33987,8 @@
     "aliases": [],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤽🏿"
+    "moji": "🤽🏿",
+    "emoji_order": 10089
   },
   "watermelon": {
     "unicode": "1F349",
@@ -32280,7 +34006,8 @@
       "summer",
       "large"
     ],
-    "moji": "🍉"
+    "moji": "🍉",
+    "emoji_order": 358
   },
   "wave": {
     "unicode": "1F44B",
@@ -32300,7 +34027,8 @@
       "hi",
       "diversity"
     ],
-    "moji": "👋"
+    "moji": "👋",
+    "emoji_order": 90
   },
   "wave_tone1": {
     "unicode": "1F44B-1F3FB",
@@ -32318,7 +34046,8 @@
       "hi",
       "wave"
     ],
-    "moji": "👋🏻"
+    "moji": "👋🏻",
+    "emoji_order": 1305
   },
   "wave_tone2": {
     "unicode": "1F44B-1F3FC",
@@ -32336,7 +34065,8 @@
       "hi",
       "wave"
     ],
-    "moji": "👋🏼"
+    "moji": "👋🏼",
+    "emoji_order": 1306
   },
   "wave_tone3": {
     "unicode": "1F44B-1F3FD",
@@ -32354,7 +34084,8 @@
       "hi",
       "wave"
     ],
-    "moji": "👋🏽"
+    "moji": "👋🏽",
+    "emoji_order": 1307
   },
   "wave_tone4": {
     "unicode": "1F44B-1F3FE",
@@ -32372,7 +34103,8 @@
       "hi",
       "wave"
     ],
-    "moji": "👋🏾"
+    "moji": "👋🏾",
+    "emoji_order": 1308
   },
   "wave_tone5": {
     "unicode": "1F44B-1F3FF",
@@ -32390,7 +34122,8 @@
       "hi",
       "wave"
     ],
-    "moji": "👋🏿"
+    "moji": "👋🏿",
+    "emoji_order": 1309
   },
   "wavy_dash": {
     "unicode": "3030",
@@ -32405,7 +34138,8 @@
       "line",
       "symbol"
     ],
-    "moji": "〰"
+    "moji": "〰",
+    "emoji_order": 955
   },
   "waxing_crescent_moon": {
     "unicode": "1F312",
@@ -32425,7 +34159,8 @@
       "phase",
       "space"
     ],
-    "moji": "🌒"
+    "moji": "🌒",
+    "emoji_order": 313
   },
   "waxing_gibbous_moon": {
     "unicode": "1F314",
@@ -32441,7 +34176,8 @@
       "sky",
       "moon"
     ],
-    "moji": "🌔"
+    "moji": "🌔",
+    "emoji_order": 315
   },
   "wc": {
     "unicode": "1F6BE",
@@ -32465,7 +34201,8 @@
       "plumbing",
       "symbol"
     ],
-    "moji": "🚾"
+    "moji": "🚾",
+    "emoji_order": 885
   },
   "weary": {
     "unicode": "1F629",
@@ -32491,7 +34228,8 @@
       "stressed",
       "emotion"
     ],
-    "moji": "😩"
+    "moji": "😩",
+    "emoji_order": 48
   },
   "wedding": {
     "unicode": "1F492",
@@ -32514,7 +34252,8 @@
       "building",
       "parties"
     ],
-    "moji": "💒"
+    "moji": "💒",
+    "emoji_order": 584
   },
   "whale": {
     "unicode": "1F433",
@@ -32533,7 +34272,8 @@
       "tropical",
       "whales"
     ],
-    "moji": "🐳"
+    "moji": "🐳",
+    "emoji_order": 249
   },
   "whale2": {
     "unicode": "1F40B",
@@ -32558,7 +34298,8 @@
       "tropical",
       "whales"
     ],
-    "moji": "🐋"
+    "moji": "🐋",
+    "emoji_order": 250
   },
   "wheel_of_dharma": {
     "unicode": "2638",
@@ -32573,7 +34314,8 @@
       "religion",
       "symbol"
     ],
-    "moji": "☸"
+    "moji": "☸",
+    "emoji_order": 788
   },
   "wheelchair": {
     "unicode": "267F",
@@ -32590,7 +34332,8 @@
       "disabled",
       "symbol"
     ],
-    "moji": "♿"
+    "moji": "♿",
+    "emoji_order": 883
   },
   "white_check_mark": {
     "unicode": "2705",
@@ -32606,7 +34349,8 @@
       "ok",
       "symbol"
     ],
-    "moji": "✅"
+    "moji": "✅",
+    "emoji_order": 871
   },
   "white_circle": {
     "unicode": "26AA",
@@ -32624,7 +34368,8 @@
       "symbol",
       "circle"
     ],
-    "moji": "⚪"
+    "moji": "⚪",
+    "emoji_order": 975
   },
   "white_flower": {
     "unicode": "1F4AE",
@@ -32650,7 +34395,8 @@
       "praise",
       "symbol"
     ],
-    "moji": "💮"
+    "moji": "💮",
+    "emoji_order": 824
   },
   "white_large_square": {
     "unicode": "2B1C",
@@ -32668,7 +34414,8 @@
       "symbol",
       "square"
     ],
-    "moji": "⬜"
+    "moji": "⬜",
+    "emoji_order": 987
   },
   "white_medium_small_square": {
     "unicode": "25FD",
@@ -32686,7 +34433,8 @@
       "symbol",
       "square"
     ],
-    "moji": "◽"
+    "moji": "◽",
+    "emoji_order": 992
   },
   "white_medium_square": {
     "unicode": "25FB",
@@ -32704,7 +34452,8 @@
       "symbol",
       "square"
     ],
-    "moji": "◻"
+    "moji": "◻",
+    "emoji_order": 990
   },
   "white_small_square": {
     "unicode": "25AB",
@@ -32722,7 +34471,8 @@
       "symbol",
       "square"
     ],
-    "moji": "▫"
+    "moji": "▫",
+    "emoji_order": 985
   },
   "white_square_button": {
     "unicode": "1F533",
@@ -32738,7 +34488,8 @@
       "symbol",
       "square"
     ],
-    "moji": "🔳"
+    "moji": "🔳",
+    "emoji_order": 994
   },
   "white_sun_cloud": {
     "unicode": "1F325",
@@ -32758,7 +34509,8 @@
       "cold",
       "sun"
     ],
-    "moji": "🌥"
+    "moji": "🌥",
+    "emoji_order": 330
   },
   "white_sun_rain_cloud": {
     "unicode": "1F326",
@@ -32779,7 +34531,8 @@
       "rain",
       "sun"
     ],
-    "moji": "🌦"
+    "moji": "🌦",
+    "emoji_order": 331
   },
   "white_sun_small_cloud": {
     "unicode": "1F324",
@@ -32798,7 +34551,8 @@
       "cloud",
       "sun"
     ],
-    "moji": "🌤"
+    "moji": "🌤",
+    "emoji_order": 328
   },
   "wilted_rose": {
     "unicode": "1F940",
@@ -32811,7 +34565,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🥀"
+    "moji": "🥀",
+    "emoji_order": 10136
   },
   "wind_blowing_face": {
     "unicode": "1F32C",
@@ -32827,7 +34582,8 @@
       "weather",
       "cold"
     ],
-    "moji": "🌬"
+    "moji": "🌬",
+    "emoji_order": 343
   },
   "wind_chime": {
     "unicode": "1F390",
@@ -32854,7 +34610,8 @@
       "object",
       "japan"
     ],
-    "moji": "🎐"
+    "moji": "🎐",
+    "emoji_order": 698
   },
   "wine_glass": {
     "unicode": "1F377",
@@ -32881,7 +34638,8 @@
       "girls night",
       "parties"
     ],
-    "moji": "🍷"
+    "moji": "🍷",
+    "emoji_order": 409
   },
   "wink": {
     "unicode": "1F609",
@@ -32913,7 +34671,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😉"
+    "moji": "😉",
+    "emoji_order": 10
   },
   "wolf": {
     "unicode": "1F43A",
@@ -32929,7 +34688,8 @@
       "wildlife",
       "roar"
     ],
-    "moji": "🐺"
+    "moji": "🐺",
+    "emoji_order": 231
   },
   "woman": {
     "unicode": "1F469",
@@ -32950,7 +34710,8 @@
       "selfie",
       "girls night"
     ],
-    "moji": "👩"
+    "moji": "👩",
+    "emoji_order": 125
   },
   "woman_tone1": {
     "unicode": "1F469-1F3FB",
@@ -32965,7 +34726,8 @@
       "girl",
       "lady"
     ],
-    "moji": "👩🏻"
+    "moji": "👩🏻",
+    "emoji_order": 1445
   },
   "woman_tone2": {
     "unicode": "1F469-1F3FC",
@@ -32980,7 +34742,8 @@
       "girl",
       "lady"
     ],
-    "moji": "👩🏼"
+    "moji": "👩🏼",
+    "emoji_order": 1446
   },
   "woman_tone3": {
     "unicode": "1F469-1F3FD",
@@ -32995,7 +34758,8 @@
       "girl",
       "lady"
     ],
-    "moji": "👩🏽"
+    "moji": "👩🏽",
+    "emoji_order": 1447
   },
   "woman_tone4": {
     "unicode": "1F469-1F3FE",
@@ -33010,7 +34774,8 @@
       "girl",
       "lady"
     ],
-    "moji": "👩🏾"
+    "moji": "👩🏾",
+    "emoji_order": 1448
   },
   "woman_tone5": {
     "unicode": "1F469-1F3FF",
@@ -33025,7 +34790,8 @@
       "girl",
       "lady"
     ],
-    "moji": "👩🏿"
+    "moji": "👩🏿",
+    "emoji_order": 1449
   },
   "womans_clothes": {
     "unicode": "1F45A",
@@ -33051,7 +34817,8 @@
       "dressed",
       "women"
     ],
-    "moji": "👚"
+    "moji": "👚",
+    "emoji_order": 176
   },
   "womans_hat": {
     "unicode": "1F452",
@@ -33067,7 +34834,8 @@
       "female",
       "women"
     ],
-    "moji": "👒"
+    "moji": "👒",
+    "emoji_order": 191
   },
   "womens": {
     "unicode": "1F6BA",
@@ -33088,7 +34856,8 @@
       "avatar",
       "symbol"
     ],
-    "moji": "🚺"
+    "moji": "🚺",
+    "emoji_order": 889
   },
   "worried": {
     "unicode": "1F61F",
@@ -33110,7 +34879,8 @@
       "smiley",
       "emotion"
     ],
-    "moji": "😟"
+    "moji": "😟",
+    "emoji_order": 38
   },
   "wrench": {
     "unicode": "1F527",
@@ -33127,7 +34897,8 @@
       "object",
       "tool"
     ],
-    "moji": "🔧"
+    "moji": "🔧",
+    "emoji_order": 645
   },
   "wrestlers": {
     "unicode": "1F93C",
@@ -33140,7 +34911,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤼"
+    "moji": "🤼",
+    "emoji_order": 10157
   },
   "wrestlers_tone1": {
     "unicode": "1F93C-1F3FB",
@@ -33153,7 +34925,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤼🏻"
+    "moji": "🤼🏻",
+    "emoji_order": 10080
   },
   "wrestlers_tone2": {
     "unicode": "1F93C-1F3FC",
@@ -33166,7 +34939,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤼🏼"
+    "moji": "🤼🏼",
+    "emoji_order": 10081
   },
   "wrestlers_tone3": {
     "unicode": "1F93C-1F3FD",
@@ -33179,7 +34953,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤼🏽"
+    "moji": "🤼🏽",
+    "emoji_order": 10082
   },
   "wrestlers_tone4": {
     "unicode": "1F93C-1F3FE",
@@ -33192,7 +34967,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤼🏾"
+    "moji": "🤼🏾",
+    "emoji_order": 10083
   },
   "wrestlers_tone5": {
     "unicode": "1F93C-1F3FF",
@@ -33205,7 +34981,8 @@
     ],
     "aliases_ascii": [],
     "keywords": [],
-    "moji": "🤼🏿"
+    "moji": "🤼🏿",
+    "emoji_order": 10084
   },
   "writing_hand": {
     "unicode": "270D",
@@ -33223,7 +35000,8 @@
       "write",
       "diversity"
     ],
-    "moji": "✍"
+    "moji": "✍",
+    "emoji_order": 110
   },
   "writing_hand_tone1": {
     "unicode": "270D-1F3FB",
@@ -33239,7 +35017,8 @@
       "signature",
       "draw"
     ],
-    "moji": "✍🏻"
+    "moji": "✍🏻",
+    "emoji_order": 1405
   },
   "writing_hand_tone2": {
     "unicode": "270D-1F3FC",
@@ -33255,7 +35034,8 @@
       "signature",
       "draw"
     ],
-    "moji": "✍🏼"
+    "moji": "✍🏼",
+    "emoji_order": 1406
   },
   "writing_hand_tone3": {
     "unicode": "270D-1F3FD",
@@ -33271,7 +35051,8 @@
       "signature",
       "draw"
     ],
-    "moji": "✍🏽"
+    "moji": "✍🏽",
+    "emoji_order": 1407
   },
   "writing_hand_tone4": {
     "unicode": "270D-1F3FE",
@@ -33287,7 +35068,8 @@
       "signature",
       "draw"
     ],
-    "moji": "✍🏾"
+    "moji": "✍🏾",
+    "emoji_order": 1408
   },
   "writing_hand_tone5": {
     "unicode": "270D-1F3FF",
@@ -33303,7 +35085,8 @@
       "signature",
       "draw"
     ],
-    "moji": "✍🏿"
+    "moji": "✍🏿",
+    "emoji_order": 1409
   },
   "x": {
     "unicode": "274C",
@@ -33320,7 +35103,8 @@
       "symbol",
       "sol"
     ],
-    "moji": "❌"
+    "moji": "❌",
+    "emoji_order": 840
   },
   "yellow_heart": {
     "unicode": "1F49B",
@@ -33349,7 +35133,8 @@
       "selfless",
       "symbol"
     ],
-    "moji": "💛"
+    "moji": "💛",
+    "emoji_order": 770
   },
   "yen": {
     "unicode": "1F4B4",
@@ -33371,7 +35156,8 @@
       "cash",
       "bill"
     ],
-    "moji": "💴"
+    "moji": "💴",
+    "emoji_order": 638
   },
   "yin_yang": {
     "unicode": "262F",
@@ -33388,7 +35174,8 @@
       "tao",
       "taoist"
     ],
-    "moji": "☯"
+    "moji": "☯",
+    "emoji_order": 792
   },
   "yum": {
     "unicode": "1F60B",
@@ -33418,7 +35205,8 @@
       "sarcastic",
       "good"
     ],
-    "moji": "😋"
+    "moji": "😋",
+    "emoji_order": 15
   },
   "zap": {
     "unicode": "26A1",
@@ -33437,7 +35225,8 @@
       "sky",
       "diarrhea"
     ],
-    "moji": "⚡"
+    "moji": "⚡",
+    "emoji_order": 336
   },
   "zero": {
     "moji": "0️⃣",
@@ -33457,7 +35246,8 @@
       "number",
       "math",
       "symbol"
-    ]
+    ],
+    "emoji_order": 902
   },
   "zipper_mouth": {
     "unicode": "1F910",
@@ -33473,7 +35263,8 @@
       "mad",
       "smiley"
     ],
-    "moji": "🤐"
+    "moji": "🤐",
+    "emoji_order": 64
   },
   "zzz": {
     "unicode": "1F4A4",
@@ -33488,6 +35279,7 @@
       "tired",
       "goodnight"
     ],
-    "moji": "💤"
+    "moji": "💤",
+    "emoji_order": 69
   }
 }


### PR DESCRIPTION
It seems some stuff need to be taken care for this to be consistent:
- [ ] Sort definition file by `emoji_order` instead of alphabetically 
- [ ] Some gaps exist between ranges:

After number 1624 it skips to 10000. (could be because those on the 10000 are the new unicode 9 emoji an there is no official ordered yet, but not sure).

After 10074 it skips to 10080.
10100 and 10102 are missing. 

What I was able to check from the source repo is that: 
- 10100 corresponds to`speech_left` that was removed in the latest release. Could think on adding it back (yet it seems weird this definition has this order).
- 10102 corresponds to `gay_pride_flag` that is not even part of the assets yet.
- 10074 to 10080 is indeed missing in the source too.

This would resolve #20 

This is related to Ranks/emojione#309
