### PR TITLE
Add find by keyword method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Emoji Library Index APIs:
 => {"moji"=>"❤", "unicode"=>"2764", "unicode_alternates"=>["2764-FE0F"], "name"=>"heart", "shortname"=>":heart:", "category"=>"symbols", "aliases"=>[], "aliases_ascii"=>["<3"], "keywords"=>["like", "love", "red", "pink", "black", "heart", "love", "passion", "romance", "intense", "desire", "death", "evil", "cold", "valentines"], "description"=>"heavy black heart"}
 
 > index.find_by_keyword('teeth')
-=> [{"unicode":"1F62C","unicode_alternates":[],"name":"grimacing face","shortname":":grimacing:","category":"people","aliases":[],"aliases_ascii":[],"keywords":["face","grimace","teeth","disapprove","pain","silly","smiley","emotion","selfie"],"moji":"😬"},{"unicode":"1F479","unicode_alternates":[],"name":"japanese ogre","shortname":":japanese_ogre:","category":"people","aliases":[],"aliases_ascii":[],"keywords":["monster","japanese","oni","demon","troll","ogre","folklore","devil","mask","theater","horns","teeth"],"moji":"👹"}]
+=> [{"unicode"=>"1F62C", "unicode_alternates"=>[], "name"=>"grimacing", "shortname"=>":grimacing:", "category"=>"people", "aliases"=>[], "aliases_ascii"=>[], "keywords"=>["face", "grimace", "teeth", "disapprove", "pain", "silly", "smiley", "emotion", "selfie"], "moji"=>"😬", "description"=>"grimacing face"}, {"unicode"=>"1F479", "unicode_alternates"=>[], "name"=>"japanese_ogre", "shortname"=>":japanese_ogre:", "category"=>"people", "aliases"=>[], "aliases_ascii"=>[], "keywords"=>["monster", "japanese", "oni", "demon", "troll", "ogre", "folklore", "devil", "mask", "theater", "horns", "teeth"], "moji"=>"👹", "description"=>"japanese ogre"}]
 ```
 Default configuration integrates with Rails, but you can change it with an initializer:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Emoji Library Index APIs:
 
 > index.find_by_moji('❤')
 => {"moji"=>"❤", "unicode"=>"2764", "unicode_alternates"=>["2764-FE0F"], "name"=>"heart", "shortname"=>":heart:", "category"=>"symbols", "aliases"=>[], "aliases_ascii"=>["<3"], "keywords"=>["like", "love", "red", "pink", "black", "heart", "love", "passion", "romance", "intense", "desire", "death", "evil", "cold", "valentines"], "description"=>"heavy black heart"}
+
+> index.find_by_keyword('teeth')
+=> [{"unicode":"1F62C","unicode_alternates":[],"name":"grimacing face","shortname":":grimacing:","category":"people","aliases":[],"aliases_ascii":[],"keywords":["face","grimace","teeth","disapprove","pain","silly","smiley","emotion","selfie"],"moji":"😬"},{"unicode":"1F479","unicode_alternates":[],"name":"japanese ogre","shortname":":japanese_ogre:","category":"people","aliases":[],"aliases_ascii":[],"keywords":["monster","japanese","oni","demon","troll","ogre","folklore","devil","mask","theater","horns","teeth"],"moji":"👹"}]
 ```
 Default configuration integrates with Rails, but you can change it with an initializer:
 

--- a/lib/gemojione/index.rb
+++ b/lib/gemojione/index.rb
@@ -10,6 +10,7 @@ module Gemojione
       @emoji_by_moji = {}
       @emoji_by_ascii = {}
       @emoji_by_code = {}
+      @emoji_by_keyword = {}
 
       emoji_list.each do |key, emoji_hash|
 
@@ -31,6 +32,12 @@ module Gemojione
 
         moji = emoji_hash['moji']
         @emoji_by_moji[moji] = emoji_hash if moji
+
+        emoji_hash['keywords'].each do |emoji_keyword|
+          inner = @emoji_by_keyword.key?(:emoji_keyword) ? @emoji_by_keyword[emoji_keyword] : Array.new
+          inner.push(emoji_hash)
+          @emoji_by_keyword[emoji_keyword] = inner if inner
+        end
       end
 
       @emoji_code_regex = /#{@emoji_by_code.keys.map{|ec| Regexp.escape(ec)}.join('|')}/
@@ -47,6 +54,10 @@ module Gemojione
 
     def find_by_ascii(ascii)
       @emoji_by_ascii[ascii]
+    end
+
+    def find_by_keyword(keyword)
+      @emoji_by_keyword[keyword]
     end
 
     def unicode_moji_regex

--- a/lib/gemojione/index.rb
+++ b/lib/gemojione/index.rb
@@ -34,9 +34,8 @@ module Gemojione
         @emoji_by_moji[moji] = emoji_hash if moji
 
         emoji_hash['keywords'].each do |emoji_keyword|
-          inner = @emoji_by_keyword.key?(:emoji_keyword) ? @emoji_by_keyword[emoji_keyword] : Array.new
-          inner.push(emoji_hash)
-          @emoji_by_keyword[emoji_keyword] = inner if inner
+          @emoji_by_keyword[emoji_keyword] ||= []
+          @emoji_by_keyword[emoji_keyword] << emoji_hash
         end
       end
 

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -17,6 +17,16 @@ describe Gemojione::Index do
     end
   end
 
+  describe "find_by_keyword" do
+    it 'should find all emoji with glasses keyword' do
+      glasses_emoji = index.find_by_keyword('glasses')
+      assert glasses_emoji
+      glasses_emoji.each do |emoji_hash|
+        assert_includes(emoji_hash['keywords'], 'glasses')
+      end
+    end
+  end
+
   describe 'find by ascii' do
     it 'returns the heart emoji' do
       assert index.find_by_ascii('<3')['unicode'] == "2764"

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -21,6 +21,7 @@ describe Gemojione::Index do
     it 'should find all emoji with glasses keyword' do
       glasses_emoji = index.find_by_keyword('glasses')
       assert glasses_emoji
+      assert glasses_emoji.length == 5
       glasses_emoji.each do |emoji_hash|
         assert_includes(emoji_hash['keywords'], 'glasses')
       end


### PR DESCRIPTION
New method to find emoji definitions by keyword. It returns an array of emoji definitions that has involved keyword in their corresponding `keywords` array.

Usage example added to README.

This resolves #23 
