### PR TITLE
Add helper for named mojis as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ and call methods directly on your string to return the same results:
 > 'I ❤ Emoji'.with_emoji_images
 => "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/assets/emoji/2764.png\"> Emoji"
 
+> 'I :heart: Emoji'.with_emoji_names
+=> "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/assets/emoji/2764.png\"> Emoji"
+
 > 'heart'.image_url
 > '❤'.image_url
 => "http://localhost:3000/assets/emoji/2764.png"

--- a/lib/gemojione/string_ext.rb
+++ b/lib/gemojione/string_ext.rb
@@ -3,6 +3,10 @@ class String
     Gemojione.replace_unicode_moji_with_images(self)
   end
 
+  def with_emoji_names
+    Gemojione.replace_named_moji_with_images(self)
+  end
+
   def image_url
     Gemojione.image_url_for_name(self.emoji_data['name'])
   end

--- a/test/string_ext_test.rb
+++ b/test/string_ext_test.rb
@@ -11,6 +11,14 @@ describe String, 'with Emoji extensions' do
     end
   end
 
+  describe '#with_emoji_names' do
+    it 'should replace named moji with an img tag' do
+      base_string = "I :heart: Emoji"
+      replaced_string = base_string.with_emoji_names
+      assert_equal "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/2764.png\"> Emoji", replaced_string
+    end
+  end
+
   describe '#image_url' do
     it 'should generate image_url' do
       assert_equal 'http://localhost:3000/1F300.png', '🌀'.image_url


### PR DESCRIPTION
I’ve noticed that there were 3 helpers for 4 of the main image replacement API calls, so I decided to add the missing one (which was the one I actually missed while using this gem).

I’m not passionate about its name (`with_emoji_names`) so I’m quite open to suggestions. 😃  
Thanks for such a great gem, by the way! 💎 ✅ 🙇 
