### PR TITLE
Add a way to cache and return SVG files

### DIFF
--- a/lib/gemojione.rb
+++ b/lib/gemojione.rb
@@ -23,6 +23,8 @@ module Gemojione
 
   @escaper = defined?(EscapeUtils) ? EscapeUtils : CGI
 
+  @emoji_svg = {}
+
   def self.asset_host
     @asset_host || 'http://localhost:3000'
   end
@@ -198,5 +200,12 @@ module Gemojione
 
   def self.sprites_path
     File.expand_path("../assets/sprites", File.dirname(__FILE__))
+  end
+
+  def self.svg_for_name(name) # heart, not :heart:
+    if index.find_by_name(name)
+      moji = index.find_by_name(name)
+      @emoji_svg[name] ||= File.read(File.absolute_path(File.expand_path("../assets/svg", File.dirname(__FILE__)) + "/#{moji['unicode']}.svg"))
+    end
   end
 end


### PR DESCRIPTION
I built a small Jekyll plugin based on html-pipeline that uses Gemojione to embed SVG emojis.

This pull request includes the changes I needed (the other one is #42, which is already merged).