### PR TITLE
Remove :anguished: alias from :frowning:

### DIFF
--- a/config/index.json
+++ b/config/index.json
@@ -18413,7 +18413,7 @@
     "shortname": ":frowning:",
     "category": "people",
     "aliases": [
-      ":anguished:"
+
     ],
     "aliases_ascii": [
 


### PR DESCRIPTION
The shortname :anguished: already exists. Shortnames should be uniques
so an alias should never collide with an actual shortname.