### PR TITLE
Add replace_named_moji_with_unicode_moji method

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ Emoji Library Index APIs:
 => {"unicode"=>"1F604", "unicode_alternates"=>[], "name"=>"smile", "shortname"=>":smile:", "category"=>"people", "aliases"=>[], "aliases_ascii"=>[":)", ":-)", "=]", "=)", ":]"], "keywords"=>["face", "funny", "haha", "happy", "joy", "laugh", "smile", "smiley", "smiling", "emotion"], "moji"=>"😄","description"=>"smiling face with open mouth and smiling eyes"}
 ```
 
+Other:
+
+```ruby
+> Gemojione.replace_named_moji_with_unicode_moji("Going for a walk! :woman_walking:")
+=> "Going for a walk! 🚶‍♀️"
+```
+
 Default configuration integrates with Rails, but you can change it with an initializer:
 
 ```ruby

--- a/gemojione.gemspec
+++ b/gemojione.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "json"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "sprite-factory"

--- a/lib/gemojione.rb
+++ b/lib/gemojione.rb
@@ -124,6 +124,24 @@ module Gemojione
     safe_string
   end
 
+  def self.replace_named_moji_with_unicode_moji(string)
+    return string unless string
+    unless string.match(index.shortname_moji_regex)
+      return safe_string(string)
+    end
+
+    safe_string = safe_string(string.dup)
+    safe_string.gsub!(index.shortname_moji_regex) do |code|
+      name = code.tr(':','')
+      moji = index.find_by_name(name)
+      moji['moji']
+    end
+
+    safe_string = safe_string.html_safe if safe_string.respond_to?(:html_safe)
+
+    safe_string
+  end
+
   def self.replace_ascii_moji_with_images(string)
     return string unless string
     unless string.match(index.ascii_moji_regex)

--- a/lib/gemojione/version.rb
+++ b/lib/gemojione/version.rb
@@ -1,3 +1,3 @@
 module Gemojione
-  VERSION = "4.2.0"
+  VERSION = "4.3.0"
 end

--- a/test/gemojione_test.rb
+++ b/test/gemojione_test.rb
@@ -263,6 +263,13 @@ describe Gemojione do
     end
   end
 
+  describe 'replace_named_moji_with_unicode_moji' do
+    it 'should replace emoji name with unicode moji' do
+      replaced_string = Gemojione.replace_named_moji_with_unicode_moji("Going for a walk! :woman_walking:")
+      assert_equal "Going for a walk! 🚶‍♀️", replaced_string
+    end
+  end
+
   describe "replace_ascii_moji_with_images" do
     it 'should replace ascii moji with img tag' do
       replaced_string = Gemojione.replace_ascii_moji_with_images("Emoji is :-)")


### PR DESCRIPTION
Add a method for replacing named moji (eg, `:woman_walking:`) with unicode character (eg 🚶‍♀️).

