### PR TITLE
Change name on to large_blue_circle

### DIFF
--- a/config/index.json
+++ b/config/index.json
@@ -22591,7 +22591,7 @@
     ],
     "moji": "🏷"
   },
-  "blue_circle": {
+  "large_blue_circle": {
     "unicode": "1F535",
     "unicode_alternates": [
 


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/story/show/168668406)

What I did:
1. Looked at the args in the airbrake which was the Bonus id (5d83eb903dcdc000c8bfa8da).
2. Got bonus from db to see it's reason which had following emojis ":large_blue_circle: :fox_face: :flag-in:"
3. large_blue_circle was listed wrong as `blue_circle`