### PR TITLE
Be explicit about emoji_list encoding

### DIFF
--- a/lib/gemojione/index.rb
+++ b/lib/gemojione/index.rb
@@ -4,7 +4,7 @@ module Gemojione
 
     def initialize(emoji_list=nil)
       emoji_list ||= begin
-        emoji_json = File.read(File.absolute_path(File.dirname(__FILE__) + '/../../config/index.json'))
+        emoji_json = File.read(File.absolute_path(File.dirname(__FILE__) + '/../../config/index.json'), :encoding => 'UTF-8')
         JSON.parse(emoji_json)
       end
 


### PR DESCRIPTION
On Windows, `Index.initialize` was causing the following error:

`Encoding::UndefinedConversionError:: "\x8F" to UTF-8 in conversion from Windows-1252 to UTF-8`

Fixed by specifying the encoding explicitly in the `File.read` call.